### PR TITLE
(maint) Add CSV export functionality for draft state data

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -193,6 +193,20 @@ This allows frontend to handle errors appropriately:
 **Behavior:** Returns draft configuration including budgets, position limits, and total rounds  
 **Usage:** Used by frontend for client-side budget validation
 
+### GET /api/v1/export/csv
+**Purpose:** Export current draft state as CSV file for external analysis  
+**Response:** CSV file download with proper headers for browser download  
+**Content-Type:** `text/csv; charset=utf-8`  
+**Content-Disposition:** `attachment; filename=draft_export.csv`  
+**Behavior:** 
+  - Generates structured CSV with owner columns and player/price data
+  - First row: Owner names alternating with empty cells ("Adam","","Jodi","",...)
+  - Second row: Alternating "Player" and "$" headers for each owner
+  - Data rows: Player names in "Last, First" format with corresponding prices
+  - Players grouped under their respective owners based on draft picks
+  - Handles variable pick counts (empty cells for owners with fewer picks)
+  - Uses atomic data loading for consistency with current draft state
+
 ### GET /api/v1/teams/{owner_id}
 **Purpose:** Get specific team roster with player details  
 **Response:** JSON with team info and full player/price data  

--- a/README.md
+++ b/README.md
@@ -210,4 +210,3 @@ netsh advfirewall firewall add rule name="FFDraftTracker" dir=in action=allow pr
   - It's because we send the expected version number
   - perhaps we need to pass the version number as part of the url?
 - need to add a parser to ffdrafttool to pull in the draft-state from this tracker
-- csv export


### PR DESCRIPTION
The application previously provided JSON-based API endpoints for retrieving draft state information, teams, and player data, but lacked any mechanism for exporting draft results in a format suitable for external analysis or sharing. Users who wanted to analyze draft results in spreadsheet applications or share structured data with league members had no way to extract the information in a convenient format.

This commit introduces a new CSV export endpoint at /api/v1/export/csv that generates a structured CSV file containing the complete draft state. The CSV format organizes data with owner names in the first row alternating with empty cells, Player/$ column headers in the second row, and player names with prices in subsequent rows grouped by owner. The endpoint returns proper HTTP headers for file downloads and handles variable pick counts across owners by filling empty cells appropriately.

The goal is to enable league administrators to easily export draft results for analysis in Excel or Google Sheets, share final rosters with league members, and integrate draft data with external fantasy football tools and platforms.