### PR TITLE
(maint) Enhance documentation presentation and organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Fantasy Football Draft Tracker
 
+[![CI](https://github.com/abottchen/ffdrafttracker/workflows/CI/badge.svg)](https://github.com/abottchen/ffdrafttracker/actions)
+[![Python 3.13](https://img.shields.io/badge/python-3.13-blue.svg)](https://www.python.org/downloads/)
+[![FastAPI](https://img.shields.io/badge/FastAPI-005571?logo=fastapi)](https://fastapi.tiangolo.com)
+[![API Documentation](https://img.shields.io/badge/API-Documentation-blue)](https://abottchen.github.io/ffdrafttracker/)
+
 A live auction draft tracking tool for fantasy football leagues. Features a web-based interface for managing auctions with real-time updates, optimistic locking for concurrent access, and separate admin/viewer interfaces.
 
 ## Features


### PR DESCRIPTION
The project previously had only a basic API documentation link in the README and detailed API endpoint specifications mixed with architectural decisions in DESIGN.md, creating redundancy with the live Swagger documentation and making it difficult to distinguish between usage information and design rationale.

This commit adds status badges to the README showing CI status, Python version compatibility, and FastAPI framework usage, while refactoring DESIGN.md to focus exclusively on architectural decisions and design patterns rather than API endpoint details. The API endpoint documentation is now centralized in the live Swagger interface with DESIGN.md referencing it for complete specifications.

The goal is to improve project presentation for potential users and contributors while creating clearer separation between architectural documentation and API reference materials.