### PR TITLE
(feat) Add complete defense support for fantasy football draft

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -71,7 +71,7 @@ A local fantasy football auction draft tracking tool with a web-based interface 
 
 **Data Files:**
 - `draft_state.json` - JSON representation of the pydantic DraftState object
-- `players.json` - List of all available players with their details
+- `players.json` - List of all available players and defenses with their details
 - `owners.json` - Owner information and ID mappings
 - `action_log.json` - History of all draft actions for undo capability
 - `config.json` - Application configuration (budgets, min bids, etc.)

--- a/README.md
+++ b/README.md
@@ -108,9 +108,16 @@ A live auction draft tracking tool for fantasy football leagues. Features a web-
 ```
 
 ### Player Database (`data/players.json`)
-Players with ESPN IDs for automatic image loading:
+Players and defenses with ESPN IDs for automatic image loading:
 ```json
 [
+  {
+    "id": 1,
+    "first_name": "Arizona",
+    "last_name": "Cardinals",
+    "team": "ARI",
+    "position": "D/ST"
+  },
   {
     "id": 4242335,
     "first_name": "Patrick",

--- a/data/players.json
+++ b/data/players.json
@@ -1,5 +1,229 @@
 [
   {
+    "id": 1,
+    "first_name": "Arizona",
+    "last_name": "Cardinals",
+    "team": "ARI",
+    "position": "D/ST"
+  },
+  {
+    "id": 2,
+    "first_name": "Atlanta",
+    "last_name": "Falcons",
+    "team": "ATL",
+    "position": "D/ST"
+  },
+  {
+    "id": 3,
+    "first_name": "Baltimore",
+    "last_name": "Ravens",
+    "team": "BAL",
+    "position": "D/ST"
+  },
+  {
+    "id": 4,
+    "first_name": "Buffalo",
+    "last_name": "Bills",
+    "team": "BUF",
+    "position": "D/ST"
+  },
+  {
+    "id": 5,
+    "first_name": "Carolina",
+    "last_name": "Panthers",
+    "team": "CAR",
+    "position": "D/ST"
+  },
+  {
+    "id": 6,
+    "first_name": "Chicago",
+    "last_name": "Bears",
+    "team": "CHI",
+    "position": "D/ST"
+  },
+  {
+    "id": 7,
+    "first_name": "Cincinnati",
+    "last_name": "Bengals",
+    "team": "CIN",
+    "position": "D/ST"
+  },
+  {
+    "id": 8,
+    "first_name": "Cleveland",
+    "last_name": "Browns",
+    "team": "CLE",
+    "position": "D/ST"
+  },
+  {
+    "id": 9,
+    "first_name": "Dallas",
+    "last_name": "Cowboys",
+    "team": "DAL",
+    "position": "D/ST"
+  },
+  {
+    "id": 10,
+    "first_name": "Denver",
+    "last_name": "Broncos",
+    "team": "DEN",
+    "position": "D/ST"
+  },
+  {
+    "id": 11,
+    "first_name": "Detroit",
+    "last_name": "Lions",
+    "team": "DET",
+    "position": "D/ST"
+  },
+  {
+    "id": 12,
+    "first_name": "Green Bay",
+    "last_name": "Packers",
+    "team": "GB",
+    "position": "D/ST"
+  },
+  {
+    "id": 13,
+    "first_name": "Houston",
+    "last_name": "Texans",
+    "team": "HOU",
+    "position": "D/ST"
+  },
+  {
+    "id": 14,
+    "first_name": "Indianapolis",
+    "last_name": "Colts",
+    "team": "IND",
+    "position": "D/ST"
+  },
+  {
+    "id": 15,
+    "first_name": "Jacksonville",
+    "last_name": "Jaguars",
+    "team": "JAX",
+    "position": "D/ST"
+  },
+  {
+    "id": 16,
+    "first_name": "Kansas City",
+    "last_name": "Chiefs",
+    "team": "KC",
+    "position": "D/ST"
+  },
+  {
+    "id": 17,
+    "first_name": "Los Angeles",
+    "last_name": "Chargers",
+    "team": "LAC",
+    "position": "D/ST"
+  },
+  {
+    "id": 18,
+    "first_name": "Los Angeles",
+    "last_name": "Rams",
+    "team": "LAR",
+    "position": "D/ST"
+  },
+  {
+    "id": 19,
+    "first_name": "Las Vegas",
+    "last_name": "Raiders",
+    "team": "LV",
+    "position": "D/ST"
+  },
+  {
+    "id": 20,
+    "first_name": "Miami",
+    "last_name": "Dolphins",
+    "team": "MIA",
+    "position": "D/ST"
+  },
+  {
+    "id": 21,
+    "first_name": "Minnesota",
+    "last_name": "Vikings",
+    "team": "MIN",
+    "position": "D/ST"
+  },
+  {
+    "id": 22,
+    "first_name": "New England",
+    "last_name": "Patriots",
+    "team": "NE",
+    "position": "D/ST"
+  },
+  {
+    "id": 23,
+    "first_name": "New Orleans",
+    "last_name": "Saints",
+    "team": "NO",
+    "position": "D/ST"
+  },
+  {
+    "id": 24,
+    "first_name": "New York",
+    "last_name": "Giants",
+    "team": "NYG",
+    "position": "D/ST"
+  },
+  {
+    "id": 25,
+    "first_name": "New York",
+    "last_name": "Jets",
+    "team": "NYJ",
+    "position": "D/ST"
+  },
+  {
+    "id": 26,
+    "first_name": "Philadelphia",
+    "last_name": "Eagles",
+    "team": "PHI",
+    "position": "D/ST"
+  },
+  {
+    "id": 27,
+    "first_name": "Pittsburgh",
+    "last_name": "Steelers",
+    "team": "PIT",
+    "position": "D/ST"
+  },
+  {
+    "id": 28,
+    "first_name": "Seattle",
+    "last_name": "Seahawks",
+    "team": "SEA",
+    "position": "D/ST"
+  },
+  {
+    "id": 29,
+    "first_name": "San Francisco",
+    "last_name": "49ers",
+    "team": "SF",
+    "position": "D/ST"
+  },
+  {
+    "id": 30,
+    "first_name": "Tampa Bay",
+    "last_name": "Buccaneers",
+    "team": "TB",
+    "position": "D/ST"
+  },
+  {
+    "id": 31,
+    "first_name": "Tennessee",
+    "last_name": "Titans",
+    "team": "TEN",
+    "position": "D/ST"
+  },
+  {
+    "id": 32,
+    "first_name": "Washington",
+    "last_name": "Commanders",
+    "team": "WAS",
+    "position": "D/ST"
+  },
+  {
     "id": 4429202,
     "first_name": "Israel",
     "last_name": "Abanikanda",

--- a/templates/index.html
+++ b/templates/index.html
@@ -717,6 +717,45 @@
         let highlightedIndex = -1;
         let lastDraftedPlayerId = null;
         let currentDraftState = null;
+
+        // NFL Team Logo URLs - using ESPN's CDN
+        function getTeamLogoUrl(teamAbbr) {
+            const teamMappings = {
+                'ARI': 'https://a.espncdn.com/i/teamlogos/nfl/500/ari.png',
+                'ATL': 'https://a.espncdn.com/i/teamlogos/nfl/500/atl.png',
+                'BAL': 'https://a.espncdn.com/i/teamlogos/nfl/500/bal.png',
+                'BUF': 'https://a.espncdn.com/i/teamlogos/nfl/500/buf.png',
+                'CAR': 'https://a.espncdn.com/i/teamlogos/nfl/500/car.png',
+                'CHI': 'https://a.espncdn.com/i/teamlogos/nfl/500/chi.png',
+                'CIN': 'https://a.espncdn.com/i/teamlogos/nfl/500/cin.png',
+                'CLE': 'https://a.espncdn.com/i/teamlogos/nfl/500/cle.png',
+                'DAL': 'https://a.espncdn.com/i/teamlogos/nfl/500/dal.png',
+                'DEN': 'https://a.espncdn.com/i/teamlogos/nfl/500/den.png',
+                'DET': 'https://a.espncdn.com/i/teamlogos/nfl/500/det.png',
+                'GB': 'https://a.espncdn.com/i/teamlogos/nfl/500/gb.png',
+                'HOU': 'https://a.espncdn.com/i/teamlogos/nfl/500/hou.png',
+                'IND': 'https://a.espncdn.com/i/teamlogos/nfl/500/ind.png',
+                'JAX': 'https://a.espncdn.com/i/teamlogos/nfl/500/jax.png',
+                'KC': 'https://a.espncdn.com/i/teamlogos/nfl/500/kc.png',
+                'LV': 'https://a.espncdn.com/i/teamlogos/nfl/500/lv.png',
+                'LAC': 'https://a.espncdn.com/i/teamlogos/nfl/500/lac.png',
+                'LAR': 'https://a.espncdn.com/i/teamlogos/nfl/500/lar.png',
+                'MIA': 'https://a.espncdn.com/i/teamlogos/nfl/500/mia.png',
+                'MIN': 'https://a.espncdn.com/i/teamlogos/nfl/500/min.png',
+                'NE': 'https://a.espncdn.com/i/teamlogos/nfl/500/ne.png',
+                'NO': 'https://a.espncdn.com/i/teamlogos/nfl/500/no.png',
+                'NYG': 'https://a.espncdn.com/i/teamlogos/nfl/500/nyg.png',
+                'NYJ': 'https://a.espncdn.com/i/teamlogos/nfl/500/nyj.png',
+                'PHI': 'https://a.espncdn.com/i/teamlogos/nfl/500/phi.png',
+                'PIT': 'https://a.espncdn.com/i/teamlogos/nfl/500/pit.png',
+                'SEA': 'https://a.espncdn.com/i/teamlogos/nfl/500/sea.png',
+                'SF': 'https://a.espncdn.com/i/teamlogos/nfl/500/sf.png',
+                'TB': 'https://a.espncdn.com/i/teamlogos/nfl/500/tb.png',
+                'TEN': 'https://a.espncdn.com/i/teamlogos/nfl/500/ten.png',
+                'WAS': 'https://a.espncdn.com/i/teamlogos/nfl/500/was.png'
+            };
+            return teamMappings[teamAbbr] || 'https://a.espncdn.com/i/teamlogos/nfl/500/nfl.png';
+        }
         let doneTeams = new Set();
         let config = null;
         let nominationTimerInterval = null;
@@ -892,8 +931,13 @@
                 const bidder = owners.find(o => o.id === nominated.current_bidder_id);
                 
                 if (player) {
-                    // Use the actual player's ESPN ID for the image
-                    const imageUrl = `https://a.espncdn.com/combiner/i?img=/i/headshots/nfl/players/full/${player.id}.png&w=350&h=254`;
+                    // Use team logo for defenses, player headshot for individual players
+                    let imageUrl;
+                    if (player.position === 'D/ST') {
+                        imageUrl = getTeamLogoUrl(player.team);
+                    } else {
+                        imageUrl = `https://a.espncdn.com/combiner/i?img=/i/headshots/nfl/players/full/${player.id}.png&w=350&h=254`;
+                    }
                     
                     nominationDetails.innerHTML = `
                         <img src="${imageUrl}" alt="${player.last_name}" class="nominated-player-image" onerror="this.style.display='none'">

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -879,6 +879,17 @@
             }
         }
 
+        function getDefenseByeWeek(teamAbbr) {
+            // Find bye week by looking up any player from the same team
+            for (const playerId in playerStats) {
+                const stats = playerStats[playerId];
+                if (stats && stats.team === teamAbbr && stats.bye_week) {
+                    return stats.bye_week;
+                }
+            }
+            return null; // No bye week found for this team
+        }
+
         function formatByeWeek(byeWeek) {
             if (!byeWeek || typeof byeWeek !== 'number') {
                 return '';
@@ -942,15 +953,34 @@
             
             playerList.innerHTML = sortedPicks.map(pick => {
                 const player = pick.player;
-                const imageUrl = `https://a.espncdn.com/combiner/i?img=/i/headshots/nfl/players/full/${player.id}.png&w=350&h=254`;
+                
+                // Use team logo for defenses, player headshot for individuals
+                let imageUrl;
+                if (player.position === 'D/ST') {
+                    imageUrl = getTeamLogoUrl(player.team);
+                } else {
+                    imageUrl = `https://a.espncdn.com/combiner/i?img=/i/headshots/nfl/players/full/${player.id}.png&w=350&h=254`;
+                }
+                
                 const teamLogoUrl = getTeamLogoUrl(player.team);
                 
-                const byeWeekHtml = formatByeWeek(playerStats[player.id]?.bye_week);
+                // Handle bye week for defenses by looking up a player from the same team
+                let byeWeek;
+                if (player.position === 'D/ST') {
+                    byeWeek = getDefenseByeWeek(player.team);
+                } else {
+                    byeWeek = playerStats[player.id]?.bye_week;
+                }
+                const byeWeekHtml = formatByeWeek(byeWeek);
+                
+                // Display "DST" instead of "D/ST" for better fit
+                const displayPosition = player.position === 'D/ST' ? 'DST' : player.position;
+                const cssPositionClass = player.position === 'D/ST' ? 'DST' : player.position;
                 
                 return `
                     <div class="player-card">
                         <img src="${imageUrl}" alt="${player.last_name}" class="player-image" onerror="this.style.display='none'">
-                        <span class="player-position position-${player.position}">${player.position}</span>
+                        <span class="player-position position-${cssPositionClass}">${displayPosition}</span>
                         <div class="player-info">
                             <div class="player-name">${player.first_name} ${player.last_name}</div>
                             <div class="player-meta">

--- a/utils/fetch_espn_players.py
+++ b/utils/fetch_espn_players.py
@@ -207,6 +207,98 @@ def fetch_all_players(team_filter: Optional[str] = None) -> List[Dict]:
     return all_players
 
 
+def generate_defenses() -> List[Dict]:
+    """Generate all 32 NFL defense entries using IDs 1-32."""
+    # Team city names in alphabetical order by team abbreviation
+    team_cities = {
+        "ARI": "Arizona",
+        "ATL": "Atlanta", 
+        "BAL": "Baltimore",
+        "BUF": "Buffalo",
+        "CAR": "Carolina",
+        "CHI": "Chicago",
+        "CIN": "Cincinnati", 
+        "CLE": "Cleveland",
+        "DAL": "Dallas",
+        "DEN": "Denver",
+        "DET": "Detroit",
+        "GB": "Green Bay",
+        "HOU": "Houston",
+        "IND": "Indianapolis",
+        "JAX": "Jacksonville",
+        "KC": "Kansas City",
+        "LAC": "Los Angeles",
+        "LAR": "Los Angeles", 
+        "LV": "Las Vegas",
+        "MIA": "Miami",
+        "MIN": "Minnesota",
+        "NE": "New England",
+        "NO": "New Orleans",
+        "NYG": "New York",
+        "NYJ": "New York",
+        "PHI": "Philadelphia",
+        "PIT": "Pittsburgh",
+        "SEA": "Seattle",
+        "SF": "San Francisco",
+        "TB": "Tampa Bay", 
+        "TEN": "Tennessee",
+        "WAS": "Washington"
+    }
+    
+    # Team names in alphabetical order by team abbreviation
+    team_names = {
+        "ARI": "Cardinals",
+        "ATL": "Falcons",
+        "BAL": "Ravens", 
+        "BUF": "Bills",
+        "CAR": "Panthers",
+        "CHI": "Bears",
+        "CIN": "Bengals",
+        "CLE": "Browns",
+        "DAL": "Cowboys",
+        "DEN": "Broncos", 
+        "DET": "Lions",
+        "GB": "Packers",
+        "HOU": "Texans",
+        "IND": "Colts",
+        "JAX": "Jaguars",
+        "KC": "Chiefs",
+        "LAC": "Chargers",
+        "LAR": "Rams",
+        "LV": "Raiders",
+        "MIA": "Dolphins",
+        "MIN": "Vikings", 
+        "NE": "Patriots",
+        "NO": "Saints",
+        "NYG": "Giants",
+        "NYJ": "Jets",
+        "PHI": "Eagles",
+        "PIT": "Steelers",
+        "SEA": "Seahawks",
+        "SF": "49ers",
+        "TB": "Buccaneers",
+        "TEN": "Titans",
+        "WAS": "Commanders"
+    }
+    
+    defenses = []
+    player_id = 1
+    
+    # Generate defenses in alphabetical order by team abbreviation
+    for team_abbr in sorted(team_cities.keys()):
+        defense = {
+            "id": player_id,
+            "first_name": team_cities[team_abbr],
+            "last_name": team_names[team_abbr], 
+            "team": team_abbr,
+            "position": "D/ST"
+        }
+        defenses.append(defense)
+        player_id += 1
+    
+    return defenses
+
+
 def main():
     """Main entry point."""
     # Check for team filter argument
@@ -214,28 +306,38 @@ def main():
     if len(sys.argv) > 1:
         team_filter = sys.argv[1]
     
-    # Fetch player data
+    # Generate defenses first (IDs 1-32)
+    print("Generating NFL defenses...")
+    defenses = generate_defenses()
+    print(f"Generated {len(defenses)} defenses")
+    
+    # Fetch player data from ESPN
     players = fetch_all_players(team_filter)
     
     if not players:
         print("No players fetched")
         return
     
-    # Sort players by last name, then first name
-    players.sort(key=lambda p: (p['last_name'], p['first_name']))
+    # Combine defenses and players
+    all_players = defenses + players
+    
+    # Sort players by last name, then first name (defenses will sort to top due to alphabetical city names)
+    all_players.sort(key=lambda p: (p['last_name'], p['first_name']))
     
     # Write to players.json
     output_path = Path(__file__).parent.parent / 'data' / 'players.json'
     output_path.parent.mkdir(exist_ok=True)
     
     with open(output_path, 'w') as f:
-        json.dump(players, f, indent=2)
+        json.dump(all_players, f, indent=2)
     
-    print(f"\nSuccessfully wrote {len(players)} players to {output_path}")
+    print(f"\nSuccessfully wrote {len(all_players)} players to {output_path}")
+    print(f"  - {len(defenses)} defenses (IDs 1-32)")
+    print(f"  - {len(players)} individual players")
     
     # Print summary by position
     position_counts = {}
-    for player in players:
+    for player in all_players:
         pos = player['position']
         position_counts[pos] = position_counts.get(pos, 0) + 1
     


### PR DESCRIPTION
Previously, all 32 NFL defenses were completely missing from the application despite the codebase supporting D/ST positions. Users could not draft any defenses, making the fantasy draft incomplete for standard fantasy football rules.

This commit adds comprehensive defense support by including all 32 NFL defenses in the player database with IDs 1-32 (safely chosen due to gap with existing player IDs starting at 8439+). Updates the draft interface to properly display defenses with team logos instead of player headshots, shows "DST" position labels for better UI fit, and implements "magic" bye week lookup by finding teammates from the same NFL team. Also updates the ESPN data fetch script to automatically include defenses in future data refreshes, ensuring the fix persists across database updates.