### PR TITLE
(maint) Fix critical test isolation issues corrupting production data

### DIFF
--- a/tests/integration/test_main_api.py
+++ b/tests/integration/test_main_api.py
@@ -40,7 +40,19 @@ class TestMainApiIntegration:
             CONFIG_FILE=self.config_file,
         )
         patch_paths.start()
-        self.add_cleanup(patch_paths.stop)
+        self.patch_paths = patch_paths  # Store reference for manual cleanup
+
+    def teardown_method(self):
+        """Clean up after each test method."""
+        # Restore original file paths
+        self.patch_paths.stop()
+
+        # Clean up temp directory
+        import shutil
+        try:
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
+        except Exception:
+            pass  # Ignore cleanup errors
 
     def setup_test_data(self):
         """Create test data files."""
@@ -110,10 +122,6 @@ class TestMainApiIntegration:
             json.dumps(draft_state_data, indent=2)
         )
 
-    def add_cleanup(self, func):
-        """Add cleanup function (pytest-style)."""
-        # Simple cleanup registration for this example
-        pass
 
     def test_full_auction_workflow(self):
         """Test complete auction workflow: nominate -> bid -> draft."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -240,12 +240,10 @@ class TestGetEndpoints(TestMainApp):
             ),
         ]
 
-        mock_draft_state.return_value = DraftState(
+        mock_draft_state.return_value = self.create_mock_draft_state(
             nominated=None,
             available_player_ids=[3],
-            teams=teams_with_picks,
-            next_to_nominate=1,
-            version=5,
+            teams=teams_with_picks
         )
 
         response = self.client.get("/api/v1/export/csv")
@@ -585,16 +583,14 @@ class TestPostEndpoints(TestMainApp):
             ),  # 16 players, $20 left
         ]
 
-        draft_state_with_nomination = DraftState(
-            nominated=Nominated(
-                player_id=1, current_bidder_id=1, nominating_owner_id=1, current_bid=3
-            ),
-            available_player_ids=[1, 3],
-            teams=low_budget_teams,
-            next_to_nominate=1,
-            version=5,
+        nomination = Nominated(
+            player_id=1, current_bidder_id=1, nominating_owner_id=1, current_bid=3
         )
-        mock_draft_state.return_value = draft_state_with_nomination
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            nominated=nomination,
+            available_player_ids=[1, 3],
+            teams=low_budget_teams
+        )
 
         response = self.client.post(
             "/api/v1/bid",
@@ -634,16 +630,14 @@ class TestPostEndpoints(TestMainApp):
             ),  # 16 players, $20 left
         ]
 
-        draft_state_with_nomination = DraftState(
-            nominated=Nominated(
-                player_id=1, current_bidder_id=1, nominating_owner_id=1, current_bid=3
-            ),
-            available_player_ids=[1, 3],
-            teams=sufficient_budget_teams,
-            next_to_nominate=1,
-            version=5,
+        nomination = Nominated(
+            player_id=1, current_bidder_id=1, nominating_owner_id=1, current_bid=3
         )
-        mock_draft_state.return_value = draft_state_with_nomination
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            nominated=nomination,
+            available_player_ids=[1, 3],
+            teams=sufficient_budget_teams
+        )
 
         response = self.client.post(
             "/api/v1/bid",
@@ -683,16 +677,14 @@ class TestPostEndpoints(TestMainApp):
             ),  # 18 players, $10 left
         ]
 
-        draft_state_with_nomination = DraftState(
-            nominated=Nominated(
-                player_id=1, current_bidder_id=1, nominating_owner_id=1, current_bid=3
-            ),
-            available_player_ids=[1, 3],
-            teams=teams_with_one_spot_left,
-            next_to_nominate=1,
-            version=5,
+        nomination = Nominated(
+            player_id=1, current_bidder_id=1, nominating_owner_id=1, current_bid=3
         )
-        mock_draft_state.return_value = draft_state_with_nomination
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            nominated=nomination,
+            available_player_ids=[1, 3],
+            teams=teams_with_one_spot_left
+        )
 
         response = self.client.post(
             "/api/v1/bid",
@@ -732,16 +724,14 @@ class TestPostEndpoints(TestMainApp):
             ),  # 18 players, $15 left
         ]
 
-        draft_state_with_nomination = DraftState(
-            nominated=Nominated(
-                player_id=1, current_bidder_id=1, nominating_owner_id=1, current_bid=3
-            ),
-            available_player_ids=[1, 3],
-            teams=teams_ready_to_complete,
-            next_to_nominate=1,
-            version=5,
+        nomination = Nominated(
+            player_id=1, current_bidder_id=1, nominating_owner_id=1, current_bid=3
         )
-        mock_draft_state.return_value = draft_state_with_nomination
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            nominated=nomination,
+            available_player_ids=[1, 3],
+            teams=teams_ready_to_complete
+        )
 
         response = self.client.post(
             "/api/v1/bid",
@@ -756,6 +746,10 @@ class TestPostEndpoints(TestMainApp):
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is True
+
+        # Validate business logic per DESIGN.md
+        # Uses atomic file operations
+        mock_draft_state.return_value.save_to_file.assert_called_once()
 
     @patch("main.load_draft_state")
     def test_draft_success(self, mock_draft_state):


### PR DESCRIPTION
Previous to this commit, 5 unit tests were creating real DraftState objects instead of proper mocks, causing them to write to the production data/draft_state.json file during test execution. This corrupted the production draft state and broke the development workflow, as unit tests should never perform actual file I/O operations.

This commit fixes the test isolation by replacing real DraftState instantiation with proper MagicMocks in unit tests, fixes the integration test cleanup method to properly remove temporary files, and applies necessary linting corrections. Unit tests now maintain strict isolation with full mocking, preventing any accidental writes to production data files.