### PR TITLE
(fix) Prevent Draft Player button from being cut off in nomination panel

### DIFF
--- a/static/css/draft.css
+++ b/static/css/draft.css
@@ -89,7 +89,7 @@ body {
 
 .players-grid > .nomination-panel {
   min-height: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .players-grid > .status-panel {
@@ -137,7 +137,7 @@ body {
   align-items: center;
   gap: 20px;
   justify-content: space-between;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .nomination-panel .button {
@@ -149,7 +149,8 @@ body {
   display: flex;
   align-items: center;
   gap: 20px;
-  width: 100%;
+  flex: 1;
+  min-width: 0;
 }
 
 .nomination-inputs {


### PR DESCRIPTION
Previous to this commit, the "Draft Player" button in the nomination panel was being partially cut off and disappearing off the right side of the screen when nominating a player. This was caused by overflow constraints combined with inflexible width settings that prevented proper flexbox behavior and didn't allow the button sufficient space to render completely.

This commit changes the overflow property to visible and updates the flex container to use proper flex properties instead of rigid width constraints. This allows the button to have adequate space to be fully visible while maintaining the overall layout structure and responsive behavior.