### PR TITLE
(fix) Add fallback colors for gradient text compatibility

### DIFF
--- a/docs/2025_draft_recap.html
+++ b/docs/2025_draft_recap.html
@@ -66,9 +66,11 @@
         
         .header h1 {
             font-size: 3em;
+            color: var(--text-primary);
             background: linear-gradient(135deg, var(--header-gradient-start) 0%, var(--header-gradient-end) 100%);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
+            background-clip: text;
             margin-bottom: 10px;
         }
         
@@ -293,9 +295,11 @@
         .summary-value {
             font-size: 2em;
             font-weight: bold;
+            color: var(--text-primary);
             background: linear-gradient(135deg, var(--header-gradient-start) 0%, var(--header-gradient-end) 100%);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
+            background-clip: text;
         }
         
         .summary-label {
@@ -402,9 +406,11 @@
         .summary-value {
             font-size: 2.5em;
             font-weight: 900;
+            color: var(--text-primary);
             background: linear-gradient(135deg, var(--header-gradient-start), var(--header-gradient-end));
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
+            background-clip: text;
             margin-bottom: 8px;
             line-height: 1;
         }

--- a/utils/generate_draft_recap.py
+++ b/utils/generate_draft_recap.py
@@ -267,9 +267,11 @@ def generate_html(
         
         .header h1 {{
             font-size: 3em;
+            color: var(--text-primary);
             background: linear-gradient(135deg, var(--header-gradient-start) 0%, var(--header-gradient-end) 100%);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
+            background-clip: text;
             margin-bottom: 10px;
         }}
         
@@ -494,9 +496,11 @@ def generate_html(
         .summary-value {{
             font-size: 2em;
             font-weight: bold;
+            color: var(--text-primary);
             background: linear-gradient(135deg, var(--header-gradient-start) 0%, var(--header-gradient-end) 100%);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
+            background-clip: text;
         }}
         
         .summary-label {{
@@ -603,9 +607,11 @@ def generate_html(
         .summary-value {{
             font-size: 2.5em;
             font-weight: 900;
+            color: var(--text-primary);
             background: linear-gradient(135deg, var(--header-gradient-start), var(--header-gradient-end));
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
+            background-clip: text;
             margin-bottom: 8px;
             line-height: 1;
         }}


### PR DESCRIPTION
Add fallback text colors and standard background-clip property for browsers that don't support webkit-specific text gradient effects, fixing invisible text in overview section on GitHub Pages.