### PR TITLE
(maint) Improve draft recap generation UX and fix player count bug

### DIFF
--- a/docs/2025_draft_recap.html
+++ b/docs/2025_draft_recap.html
@@ -554,1288 +554,6 @@
             <p>Auction Draft Results</p>
         </div>
         
-        <div class="layout-controls">
-            <button class="layout-toggle" id="layoutToggle" aria-label="Toggle layout">
-                <span class="layout-icon">⊞</span>
-                <span class="layout-text">Grid View</span>
-            </button>
-        </div>
-        
-        <div class="teams-grid" id="teamsGrid">
-
-            <div class="team-card">
-                <div class="team-header">
-                    <div class="team-name">Call Me The Breece</div>
-                    <div class="owner-name">Adam</div>
-                </div>
-                
-                <div class="team-stats">
-                    <div class="stat-item">
-                        <div class="stat-value">1002</div>
-                        <div class="stat-label">Players</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$195</div>
-                        <div class="stat-label">Spent</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$5</div>
-                        <div class="stat-label">Remaining</div>
-                    </div>
-                </div>
-                
-                <div class="position-badges">
-                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
-                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
-                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (6)</span>
-                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
-                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
-                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
-                </div>
-                
-                <div class="player-list">
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lar.png" class="team-logo" alt="LAR" onerror="this.style.display='none'">
-                        <span class="player-name">Kyren Williams</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$8</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/nyj.png" class="team-logo" alt="NYJ" onerror="this.style.display='none'">
-                        <span class="player-name">Breece Hall</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$14</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lar.png" class="team-logo" alt="LAR" onerror="this.style.display='none'">
-                        <span class="player-name">Puka Nacua</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$13</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
-                        <span class="player-name">Patrick Mahomes</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$31</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/sea.png" class="team-logo" alt="SEA" onerror="this.style.display='none'">
-                        <span class="player-name">Jaxon Smith-Njigba</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$26</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
-                        <span class="player-name">Travis Kelce</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$19</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/mia.png" class="team-logo" alt="MIA" onerror="this.style.display='none'">
-                        <span class="player-name">Tyreek Hill</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$30</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/nyg.png" class="team-logo" alt="NYG" onerror="this.style.display='none'">
-                        <span class="player-name">Tyrone Tracy Jr.</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$7</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ari.png" class="team-logo" alt="ARI" onerror="this.style.display='none'">
-                        <span class="player-name">Kyler Murray</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$5</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
-                        <span class="player-name">Philadelphia Eagles</span>
-                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
-                        <span class="player-price">$9</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/cle.png" class="team-logo" alt="CLE" onerror="this.style.display='none'">
-                        <span class="player-name">Jerry Jeudy</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$7</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/gb.png" class="team-logo" alt="GB" onerror="this.style.display='none'">
-                        <span class="player-name">Matthew Golden</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$11</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ten.png" class="team-logo" alt="TEN" onerror="this.style.display='none'">
-                        <span class="player-name">Tyjae Spears</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$5</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/atl.png" class="team-logo" alt="ATL" onerror="this.style.display='none'">
-                        <span class="player-name">Kyle Pitts Sr.</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$6</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ind.png" class="team-logo" alt="IND" onerror="this.style.display='none'">
-                        <span class="player-name">Michael Pittman Jr.</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$2</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
-                        <span class="player-name">Ray Davis</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
-                        <span class="player-name">Will Reichard</span>
-                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                </div>
-            </div>
-            <div class="team-card">
-                <div class="team-header">
-                    <div class="team-name">To Infinity and Bijan!</div>
-                    <div class="owner-name">Elisa</div>
-                </div>
-                
-                <div class="team-stats">
-                    <div class="stat-item">
-                        <div class="stat-value">1002</div>
-                        <div class="stat-label">Players</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$200</div>
-                        <div class="stat-label">Spent</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$0</div>
-                        <div class="stat-label">Remaining</div>
-                    </div>
-                </div>
-                
-                <div class="position-badges">
-                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
-                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (7)</span>
-                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (4)</span>
-                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
-                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
-                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
-                </div>
-                
-                <div class="player-list">
-                    <div class="player-item">
-                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
-                        <span class="player-name">Xavier Worthy</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$11</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/atl.png" class="team-logo" alt="ATL" onerror="this.style.display='none'">
-                        <span class="player-name">Bijan Robinson</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$61</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
-                        <span class="player-name">Amon-Ra St. Brown</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$61</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lac.png" class="team-logo" alt="LAC" onerror="this.style.display='none'">
-                        <span class="player-name">Omarion Hampton</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$19</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
-                        <span class="player-name">Bo Nix</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$9</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ten.png" class="team-logo" alt="TEN" onerror="this.style.display='none'">
-                        <span class="player-name">Tony Pollard</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$15</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/cle.png" class="team-logo" alt="CLE" onerror="this.style.display='none'">
-                        <span class="player-name">David Njoku</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$4</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lac.png" class="team-logo" alt="LAC" onerror="this.style.display='none'">
-                        <span class="player-name">Cameron Dicker</span>
-                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
-                        <span class="player-price">$3</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/hou.png" class="team-logo" alt="HOU" onerror="this.style.display='none'">
-                        <span class="player-name">Houston Texans</span>
-                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
-                        <span class="player-price">$4</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/nyj.png" class="team-logo" alt="NYJ" onerror="this.style.display='none'">
-                        <span class="player-name">Justin Fields</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/nyg.png" class="team-logo" alt="NYG" onerror="this.style.display='none'">
-                        <span class="player-name">Cam Skattebo</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/no.png" class="team-logo" alt="NO" onerror="this.style.display='none'">
-                        <span class="player-name">Chris Olave</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$6</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
-                        <span class="player-name">Isaiah Likely</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
-                        <span class="player-name">Jaydon Blue</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/hou.png" class="team-logo" alt="HOU" onerror="this.style.display='none'">
-                        <span class="player-name">Woody Marks</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
-                        <span class="player-name">Jacory Croskey-Merritt</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lac.png" class="team-logo" alt="LAC" onerror="this.style.display='none'">
-                        <span class="player-name">Keenan Allen</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                </div>
-            </div>
-            <div class="team-card">
-                <div class="team-header">
-                    <div class="team-name">Like a Good Nabers</div>
-                    <div class="owner-name">Greg</div>
-                </div>
-                
-                <div class="team-stats">
-                    <div class="stat-item">
-                        <div class="stat-value">1002</div>
-                        <div class="stat-label">Players</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$192</div>
-                        <div class="stat-label">Spent</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$8</div>
-                        <div class="stat-label">Remaining</div>
-                    </div>
-                </div>
-                
-                <div class="position-badges">
-                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
-                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
-                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (6)</span>
-                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
-                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
-                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
-                </div>
-                
-                <div class="player-list">
-                    <div class="player-item">
-                        <img src="2025/assets/logos/cin.png" class="team-logo" alt="CIN" onerror="this.style.display='none'">
-                        <span class="player-name">Ja'Marr Chase</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$11</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/nyg.png" class="team-logo" alt="NYG" onerror="this.style.display='none'">
-                        <span class="player-name">Malik Nabers</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$25</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
-                        <span class="player-name">Jahmyr Gibbs</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$43</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
-                        <span class="player-name">Josh Allen</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$40</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/mia.png" class="team-logo" alt="MIA" onerror="this.style.display='none'">
-                        <span class="player-name">De'Von Achane</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$40</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/cle.png" class="team-logo" alt="CLE" onerror="this.style.display='none'">
-                        <span class="player-name">Quinshon Judkins</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$7</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
-                        <span class="player-name">Dalton Kincaid</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$3</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
-                        <span class="player-name">Rome Odunze</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$8</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
-                        <span class="player-name">Tyler Loop</span>
-                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/jax.png" class="team-logo" alt="JAX" onerror="this.style.display='none'">
-                        <span class="player-name">Tank Bigsby</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$4</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
-                        <span class="player-name">Detroit Lions</span>
-                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/sf.png" class="team-logo" alt="SF" onerror="this.style.display='none'">
-                        <span class="player-name">Ricky Pearsall</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$2</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ne.png" class="team-logo" alt="NE" onerror="this.style.display='none'">
-                        <span class="player-name">Rhamondre Stevenson</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$3</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/tb.png" class="team-logo" alt="TB" onerror="this.style.display='none'">
-                        <span class="player-name">Chris Godwin</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/gb.png" class="team-logo" alt="GB" onerror="this.style.display='none'">
-                        <span class="player-name">Tucker Kraft</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/gb.png" class="team-logo" alt="GB" onerror="this.style.display='none'">
-                        <span class="player-name">Jordan Love</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/atl.png" class="team-logo" alt="ATL" onerror="this.style.display='none'">
-                        <span class="player-name">Darnell Mooney</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                </div>
-            </div>
-            <div class="team-card">
-                <div class="team-header">
-                    <div class="team-name">Blood Sweat Beers</div>
-                    <div class="owner-name">Jackie</div>
-                </div>
-                
-                <div class="team-stats">
-                    <div class="stat-item">
-                        <div class="stat-value">1002</div>
-                        <div class="stat-label">Players</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$195</div>
-                        <div class="stat-label">Spent</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$5</div>
-                        <div class="stat-label">Remaining</div>
-                    </div>
-                </div>
-                
-                <div class="position-badges">
-                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (1)</span>
-                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (4)</span>
-                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (5)</span>
-                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (1)</span>
-                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
-                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
-                </div>
-                
-                <div class="player-list">
-                    <div class="player-item">
-                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
-                        <span class="player-name">Saquon Barkley</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$51</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/nyj.png" class="team-logo" alt="NYJ" onerror="this.style.display='none'">
-                        <span class="player-name">Garrett Wilson</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$6</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/atl.png" class="team-logo" alt="ATL" onerror="this.style.display='none'">
-                        <span class="player-name">Drake London</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$20</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
-                        <span class="player-name">Jalen Hurts</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$25</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lv.png" class="team-logo" alt="LV" onerror="this.style.display='none'">
-                        <span class="player-name">Ashton Jeanty</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$50</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
-                        <span class="player-name">DJ Moore</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$17</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
-                        <span class="player-name">Evan Engram</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$3</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
-                        <span class="player-name">Minnesota Vikings</span>
-                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
-                        <span class="player-price">$6</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/sea.png" class="team-logo" alt="SEA" onerror="this.style.display='none'">
-                        <span class="player-name">Zach Charbonnet</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$5</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
-                        <span class="player-name">Kaleb Johnson</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$5</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
-                        <span class="player-name">Khalil Shakir</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$5</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/sf.png" class="team-logo" alt="SF" onerror="this.style.display='none'">
-                        <span class="player-name">Jauan Jennings</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/hou.png" class="team-logo" alt="HOU" onerror="this.style.display='none'">
-                        <span class="player-name">Ka'imi Fairbairn</span>
-                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                </div>
-            </div>
-            <div class="team-card">
-                <div class="team-header">
-                    <div class="team-name">Run CMC</div>
-                    <div class="owner-name">Jodi</div>
-                </div>
-                
-                <div class="team-stats">
-                    <div class="stat-item">
-                        <div class="stat-value">1002</div>
-                        <div class="stat-label">Players</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$200</div>
-                        <div class="stat-label">Spent</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$0</div>
-                        <div class="stat-label">Remaining</div>
-                    </div>
-                </div>
-                
-                <div class="position-badges">
-                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
-                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
-                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (6)</span>
-                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
-                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
-                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
-                </div>
-                
-                <div class="player-list">
-                    <div class="player-item">
-                        <img src="2025/assets/logos/cin.png" class="team-logo" alt="CIN" onerror="this.style.display='none'">
-                        <span class="player-name">Chase Brown</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$3</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ari.png" class="team-logo" alt="ARI" onerror="this.style.display='none'">
-                        <span class="player-name">Trey McBride</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$14</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/cin.png" class="team-logo" alt="CIN" onerror="this.style.display='none'">
-                        <span class="player-name">Tee Higgins</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$6</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/cin.png" class="team-logo" alt="CIN" onerror="this.style.display='none'">
-                        <span class="player-name">Joe Burrow</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$40</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
-                        <span class="player-name">Caleb Williams</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$8</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ne.png" class="team-logo" alt="NE" onerror="this.style.display='none'">
-                        <span class="player-name">TreVeyon Henderson</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$20</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/tb.png" class="team-logo" alt="TB" onerror="this.style.display='none'">
-                        <span class="player-name">Mike Evans</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$33</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ari.png" class="team-logo" alt="ARI" onerror="this.style.display='none'">
-                        <span class="player-name">James Conner</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$20</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
-                        <span class="player-name">RJ Harvey</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$7</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
-                        <span class="player-name">Denver Broncos</span>
-                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
-                        <span class="player-price">$9</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
-                        <span class="player-name">Colston Loveland</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$6</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ten.png" class="team-logo" alt="TEN" onerror="this.style.display='none'">
-                        <span class="player-name">Calvin Ridley</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$14</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/jax.png" class="team-logo" alt="JAX" onerror="this.style.display='none'">
-                        <span class="player-name">Travis Hunter</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$5</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/tb.png" class="team-logo" alt="TB" onerror="this.style.display='none'">
-                        <span class="player-name">Emeka Egbuka</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$5</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
-                        <span class="player-name">Wil Lutz</span>
-                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
-                        <span class="player-name">Javonte Williams</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$7</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ne.png" class="team-logo" alt="NE" onerror="this.style.display='none'">
-                        <span class="player-name">Stefon Diggs</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$2</span>
-                    </div>
-                </div>
-            </div>
-            <div class="team-card">
-                <div class="team-header">
-                    <div class="team-name">Dewey Pest Control</div>
-                    <div class="owner-name">Lance</div>
-                </div>
-                
-                <div class="team-stats">
-                    <div class="stat-item">
-                        <div class="stat-value">1002</div>
-                        <div class="stat-label">Players</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$200</div>
-                        <div class="stat-label">Spent</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$0</div>
-                        <div class="stat-label">Remaining</div>
-                    </div>
-                </div>
-                
-                <div class="position-badges">
-                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
-                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (4)</span>
-                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (7)</span>
-                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
-                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
-                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
-                </div>
-                
-                <div class="player-list">
-                    <div class="player-item">
-                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
-                        <span class="player-name">David Montgomery</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$10</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
-                        <span class="player-name">Zay Flowers</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$21</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
-                        <span class="player-name">Jayden Daniels</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$10</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/jax.png" class="team-logo" alt="JAX" onerror="this.style.display='none'">
-                        <span class="player-name">Brian Thomas Jr.</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$41</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
-                        <span class="player-name">Derrick Henry</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$46</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
-                        <span class="player-name">A.J. Brown</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$32</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
-                        <span class="player-name">Sam LaPorta</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$21</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
-                        <span class="player-name">Pittsburgh Steelers</span>
-                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
-                        <span class="player-price">$5</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
-                        <span class="player-name">Brandon Aubrey</span>
-                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
-                        <span class="player-price">$6</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
-                        <span class="player-name">Jordan Mason</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ten.png" class="team-logo" alt="TEN" onerror="this.style.display='none'">
-                        <span class="player-name">Cam Ward</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
-                        <span class="player-name">George Pickens</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
-                        <span class="player-name">Rashod Bateman</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ind.png" class="team-logo" alt="IND" onerror="this.style.display='none'">
-                        <span class="player-name">Josh Downs</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/cle.png" class="team-logo" alt="CLE" onerror="this.style.display='none'">
-                        <span class="player-name">Jerome Ford</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/gb.png" class="team-logo" alt="GB" onerror="this.style.display='none'">
-                        <span class="player-name">Jayden Reed</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
-                        <span class="player-name">Jake Ferguson</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                </div>
-            </div>
-            <div class="team-card">
-                <div class="team-header">
-                    <div class="team-name">Don't Cook the Lamb</div>
-                    <div class="owner-name">Mitch</div>
-                </div>
-                
-                <div class="team-stats">
-                    <div class="stat-item">
-                        <div class="stat-value">1002</div>
-                        <div class="stat-label">Players</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$200</div>
-                        <div class="stat-label">Spent</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$0</div>
-                        <div class="stat-label">Remaining</div>
-                    </div>
-                </div>
-                
-                <div class="position-badges">
-                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
-                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
-                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (6)</span>
-                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
-                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
-                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
-                </div>
-                
-                <div class="player-list">
-                    <div class="player-item">
-                        <img src="2025/assets/logos/hou.png" class="team-logo" alt="HOU" onerror="this.style.display='none'">
-                        <span class="player-name">C.J. Stroud</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$3</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lv.png" class="team-logo" alt="LV" onerror="this.style.display='none'">
-                        <span class="player-name">Brock Bowers</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$9</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/car.png" class="team-logo" alt="CAR" onerror="this.style.display='none'">
-                        <span class="player-name">Chuba Hubbard</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$3</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/sea.png" class="team-logo" alt="SEA" onerror="this.style.display='none'">
-                        <span class="player-name">Cooper Kupp</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$15</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
-                        <span class="player-name">Courtland Sutton</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$25</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/sea.png" class="team-logo" alt="SEA" onerror="this.style.display='none'">
-                        <span class="player-name">Kenneth Walker III</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$28</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
-                        <span class="player-name">DK Metcalf</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$15</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
-                        <span class="player-name">Aaron Jones Sr.</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$12</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
-                        <span class="player-name">Austin Ekeler</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$8</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
-                        <span class="player-name">Jameson Williams</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$12</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
-                        <span class="player-name">Deebo Samuel</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$8</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
-                        <span class="player-name">J.K. Dobbins</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$10</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
-                        <span class="player-name">Chris Boswell</span>
-                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/mia.png" class="team-logo" alt="MIA" onerror="this.style.display='none'">
-                        <span class="player-name">Jaylen Waddle</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$12</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
-                        <span class="player-name">Pat Freiermuth</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/mia.png" class="team-logo" alt="MIA" onerror="this.style.display='none'">
-                        <span class="player-name">Tua Tagovailoa</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/jax.png" class="team-logo" alt="JAX" onerror="this.style.display='none'">
-                        <span class="player-name">Jacksonville Jaguars</span>
-                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
-                        <span class="player-price">$37</span>
-                    </div>
-                </div>
-            </div>
-            <div class="team-card">
-                <div class="team-header">
-                    <div class="team-name">THE NIGHTMARE</div>
-                    <div class="owner-name">Raman</div>
-                </div>
-                
-                <div class="team-stats">
-                    <div class="stat-item">
-                        <div class="stat-value">1002</div>
-                        <div class="stat-label">Players</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$195</div>
-                        <div class="stat-label">Spent</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$5</div>
-                        <div class="stat-label">Remaining</div>
-                    </div>
-                </div>
-                
-                <div class="position-badges">
-                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (3)</span>
-                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
-                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (5)</span>
-                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
-                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
-                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
-                </div>
-                
-                <div class="player-list">
-                    <div class="player-item">
-                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
-                        <span class="player-name">James Cook</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$33</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lac.png" class="team-logo" alt="LAC" onerror="this.style.display='none'">
-                        <span class="player-name">Ladd McConkey</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$2</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/sf.png" class="team-logo" alt="SF" onerror="this.style.display='none'">
-                        <span class="player-name">George Kittle</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$23</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/sf.png" class="team-logo" alt="SF" onerror="this.style.display='none'">
-                        <span class="player-name">Christian McCaffrey</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$42</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
-                        <span class="player-name">Luther Burden III</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$4</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ari.png" class="team-logo" alt="ARI" onerror="this.style.display='none'">
-                        <span class="player-name">Marvin Harrison Jr.</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$26</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
-                        <span class="player-name">Dak Prescott</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$4</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lar.png" class="team-logo" alt="LAR" onerror="this.style.display='none'">
-                        <span class="player-name">Davante Adams</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$27</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/tb.png" class="team-logo" alt="TB" onerror="this.style.display='none'">
-                        <span class="player-name">Baker Mayfield</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$13</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/jax.png" class="team-logo" alt="JAX" onerror="this.style.display='none'">
-                        <span class="player-name">Travis Etienne Jr.</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$10</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lar.png" class="team-logo" alt="LAR" onerror="this.style.display='none'">
-                        <span class="player-name">Matthew Stafford</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
-                        <span class="player-name">Buffalo Bills</span>
-                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
-                        <span class="player-price">$3</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
-                        <span class="player-name">Dallas Goedert</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
-                        <span class="player-name">Harrison Butker</span>
-                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
-                        <span class="player-name">Kareem Hunt</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
-                        <span class="player-name">Keon Coleman</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$3</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
-                        <span class="player-name">Brian Robinson Jr.</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                </div>
-            </div>
-            <div class="team-card">
-                <div class="team-header">
-                    <div class="team-name">Sanjay's Team</div>
-                    <div class="owner-name">Sanjay</div>
-                </div>
-                
-                <div class="team-stats">
-                    <div class="stat-item">
-                        <div class="stat-value">1002</div>
-                        <div class="stat-label">Players</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$168</div>
-                        <div class="stat-label">Spent</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$32</div>
-                        <div class="stat-label">Remaining</div>
-                    </div>
-                </div>
-                
-                <div class="position-badges">
-                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
-                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
-                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (6)</span>
-                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
-                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
-                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
-                </div>
-                
-                <div class="player-list">
-                    <div class="player-item">
-                        <img src="2025/assets/logos/gb.png" class="team-logo" alt="GB" onerror="this.style.display='none'">
-                        <span class="player-name">Josh Jacobs</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$33</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
-                        <span class="player-name">Isiah Pacheco</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$9</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
-                        <span class="player-name">Jordan Addison</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$2</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
-                        <span class="player-name">Jaylen Warren</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$9</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/no.png" class="team-logo" alt="NO" onerror="this.style.display='none'">
-                        <span class="player-name">Alvin Kamara</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$18</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
-                        <span class="player-name">Terry McLaurin</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$20</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
-                        <span class="player-name">Jake Bates</span>
-                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
-                        <span class="player-price">$2</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lac.png" class="team-logo" alt="LAC" onerror="this.style.display='none'">
-                        <span class="player-name">Justin Herbert</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
-                        <span class="player-name">Mark Andrews</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$10</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
-                        <span class="player-name">DeVonta Smith</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$14</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ind.png" class="team-logo" alt="IND" onerror="this.style.display='none'">
-                        <span class="player-name">Tyler Warren</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$10</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
-                        <span class="player-name">Rashee Rice</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$8</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/car.png" class="team-logo" alt="CAR" onerror="this.style.display='none'">
-                        <span class="player-name">Tetairoa McMillan</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$12</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
-                        <span class="player-name">J.J. McCarthy</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
-                        <span class="player-name">D'Andre Swift</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$13</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/lv.png" class="team-logo" alt="LV" onerror="this.style.display='none'">
-                        <span class="player-name">Jakobi Meyers</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$5</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ne.png" class="team-logo" alt="NE" onerror="this.style.display='none'">
-                        <span class="player-name">New England Patriots</span>
-                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
-                        <span class="player-price">$1</span>
-                    </div>
-                </div>
-            </div>
-            <div class="team-card">
-                <div class="team-header">
-                    <div class="team-name">More than A. Thielen</div>
-                    <div class="owner-name">Steve</div>
-                </div>
-                
-                <div class="team-stats">
-                    <div class="stat-item">
-                        <div class="stat-value">1002</div>
-                        <div class="stat-label">Players</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$186</div>
-                        <div class="stat-label">Spent</div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="stat-value">$14</div>
-                        <div class="stat-label">Remaining</div>
-                    </div>
-                </div>
-                
-                <div class="position-badges">
-                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (1)</span>
-                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (2)</span>
-                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (3)</span>
-                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (1)</span>
-                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
-                </div>
-                
-                <div class="player-list">
-                    <div class="player-item">
-                        <img src="2025/assets/logos/ind.png" class="team-logo" alt="IND" onerror="this.style.display='none'">
-                        <span class="player-name">Jonathan Taylor</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$11</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/tb.png" class="team-logo" alt="TB" onerror="this.style.display='none'">
-                        <span class="player-name">Bucky Irving</span>
-                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
-                        <span class="player-price">$2</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
-                        <span class="player-name">Justin Jefferson</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$44</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
-                        <span class="player-name">CeeDee Lamb</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$45</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/hou.png" class="team-logo" alt="HOU" onerror="this.style.display='none'">
-                        <span class="player-name">Nico Collins</span>
-                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
-                        <span class="player-price">$41</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
-                        <span class="player-name">Lamar Jackson</span>
-                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
-                        <span class="player-price">$28</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
-                        <span class="player-name">T.J. Hockenson</span>
-                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
-                        <span class="player-price">$10</span>
-                    </div>
-                    <div class="player-item">
-                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
-                        <span class="player-name">Baltimore Ravens</span>
-                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
-                        <span class="player-price">$5</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-        
         <div class="draft-summary">
             <h2>Draft Summary & Analysis</h2>
             
@@ -2002,6 +720,1288 @@
                             <div class="position-detail"><strong>Average:</strong> $8.0</div>
                         </div>
                         <div class="position-price-display">$37</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="layout-controls">
+            <button class="layout-toggle" id="layoutToggle" aria-label="Toggle layout">
+                <span class="layout-icon">⊞</span>
+                <span class="layout-text">Grid View</span>
+            </button>
+        </div>
+        
+        <div class="teams-grid" id="teamsGrid">
+
+            <div class="team-card">
+                <div class="team-header">
+                    <div class="team-name">Call Me The Breece</div>
+                    <div class="owner-name">Adam</div>
+                </div>
+                
+                <div class="team-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">17</div>
+                        <div class="stat-label">Players</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$195</div>
+                        <div class="stat-label">Spent</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$5</div>
+                        <div class="stat-label">Remaining</div>
+                    </div>
+                </div>
+                
+                <div class="position-badges">
+                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
+                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
+                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (6)</span>
+                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
+                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
+                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
+                </div>
+                
+                <div class="player-list">
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lar.png" class="team-logo" alt="LAR" onerror="this.style.display='none'">
+                        <span class="player-name">Kyren Williams</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$8</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/nyj.png" class="team-logo" alt="NYJ" onerror="this.style.display='none'">
+                        <span class="player-name">Breece Hall</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$14</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lar.png" class="team-logo" alt="LAR" onerror="this.style.display='none'">
+                        <span class="player-name">Puka Nacua</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$13</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
+                        <span class="player-name">Patrick Mahomes</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$31</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/sea.png" class="team-logo" alt="SEA" onerror="this.style.display='none'">
+                        <span class="player-name">Jaxon Smith-Njigba</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$26</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
+                        <span class="player-name">Travis Kelce</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$19</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/mia.png" class="team-logo" alt="MIA" onerror="this.style.display='none'">
+                        <span class="player-name">Tyreek Hill</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$30</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/nyg.png" class="team-logo" alt="NYG" onerror="this.style.display='none'">
+                        <span class="player-name">Tyrone Tracy Jr.</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$7</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ari.png" class="team-logo" alt="ARI" onerror="this.style.display='none'">
+                        <span class="player-name">Kyler Murray</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$5</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
+                        <span class="player-name">Philadelphia Eagles</span>
+                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
+                        <span class="player-price">$9</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/cle.png" class="team-logo" alt="CLE" onerror="this.style.display='none'">
+                        <span class="player-name">Jerry Jeudy</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$7</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/gb.png" class="team-logo" alt="GB" onerror="this.style.display='none'">
+                        <span class="player-name">Matthew Golden</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$11</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ten.png" class="team-logo" alt="TEN" onerror="this.style.display='none'">
+                        <span class="player-name">Tyjae Spears</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$5</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/atl.png" class="team-logo" alt="ATL" onerror="this.style.display='none'">
+                        <span class="player-name">Kyle Pitts Sr.</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$6</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ind.png" class="team-logo" alt="IND" onerror="this.style.display='none'">
+                        <span class="player-name">Michael Pittman Jr.</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$2</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
+                        <span class="player-name">Ray Davis</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
+                        <span class="player-name">Will Reichard</span>
+                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                </div>
+            </div>
+            <div class="team-card">
+                <div class="team-header">
+                    <div class="team-name">To Infinity and Bijan!</div>
+                    <div class="owner-name">Elisa</div>
+                </div>
+                
+                <div class="team-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">17</div>
+                        <div class="stat-label">Players</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$200</div>
+                        <div class="stat-label">Spent</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$0</div>
+                        <div class="stat-label">Remaining</div>
+                    </div>
+                </div>
+                
+                <div class="position-badges">
+                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
+                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (7)</span>
+                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (4)</span>
+                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
+                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
+                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
+                </div>
+                
+                <div class="player-list">
+                    <div class="player-item">
+                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
+                        <span class="player-name">Xavier Worthy</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$11</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/atl.png" class="team-logo" alt="ATL" onerror="this.style.display='none'">
+                        <span class="player-name">Bijan Robinson</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$61</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
+                        <span class="player-name">Amon-Ra St. Brown</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$61</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lac.png" class="team-logo" alt="LAC" onerror="this.style.display='none'">
+                        <span class="player-name">Omarion Hampton</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$19</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
+                        <span class="player-name">Bo Nix</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$9</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ten.png" class="team-logo" alt="TEN" onerror="this.style.display='none'">
+                        <span class="player-name">Tony Pollard</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$15</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/cle.png" class="team-logo" alt="CLE" onerror="this.style.display='none'">
+                        <span class="player-name">David Njoku</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$4</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lac.png" class="team-logo" alt="LAC" onerror="this.style.display='none'">
+                        <span class="player-name">Cameron Dicker</span>
+                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
+                        <span class="player-price">$3</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/hou.png" class="team-logo" alt="HOU" onerror="this.style.display='none'">
+                        <span class="player-name">Houston Texans</span>
+                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
+                        <span class="player-price">$4</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/nyj.png" class="team-logo" alt="NYJ" onerror="this.style.display='none'">
+                        <span class="player-name">Justin Fields</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/nyg.png" class="team-logo" alt="NYG" onerror="this.style.display='none'">
+                        <span class="player-name">Cam Skattebo</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/no.png" class="team-logo" alt="NO" onerror="this.style.display='none'">
+                        <span class="player-name">Chris Olave</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$6</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
+                        <span class="player-name">Isaiah Likely</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
+                        <span class="player-name">Jaydon Blue</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/hou.png" class="team-logo" alt="HOU" onerror="this.style.display='none'">
+                        <span class="player-name">Woody Marks</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
+                        <span class="player-name">Jacory Croskey-Merritt</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lac.png" class="team-logo" alt="LAC" onerror="this.style.display='none'">
+                        <span class="player-name">Keenan Allen</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                </div>
+            </div>
+            <div class="team-card">
+                <div class="team-header">
+                    <div class="team-name">Like a Good Nabers</div>
+                    <div class="owner-name">Greg</div>
+                </div>
+                
+                <div class="team-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">17</div>
+                        <div class="stat-label">Players</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$192</div>
+                        <div class="stat-label">Spent</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$8</div>
+                        <div class="stat-label">Remaining</div>
+                    </div>
+                </div>
+                
+                <div class="position-badges">
+                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
+                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
+                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (6)</span>
+                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
+                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
+                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
+                </div>
+                
+                <div class="player-list">
+                    <div class="player-item">
+                        <img src="2025/assets/logos/cin.png" class="team-logo" alt="CIN" onerror="this.style.display='none'">
+                        <span class="player-name">Ja'Marr Chase</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$11</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/nyg.png" class="team-logo" alt="NYG" onerror="this.style.display='none'">
+                        <span class="player-name">Malik Nabers</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$25</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
+                        <span class="player-name">Jahmyr Gibbs</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$43</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
+                        <span class="player-name">Josh Allen</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$40</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/mia.png" class="team-logo" alt="MIA" onerror="this.style.display='none'">
+                        <span class="player-name">De'Von Achane</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$40</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/cle.png" class="team-logo" alt="CLE" onerror="this.style.display='none'">
+                        <span class="player-name">Quinshon Judkins</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$7</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
+                        <span class="player-name">Dalton Kincaid</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$3</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
+                        <span class="player-name">Rome Odunze</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$8</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
+                        <span class="player-name">Tyler Loop</span>
+                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/jax.png" class="team-logo" alt="JAX" onerror="this.style.display='none'">
+                        <span class="player-name">Tank Bigsby</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$4</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
+                        <span class="player-name">Detroit Lions</span>
+                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/sf.png" class="team-logo" alt="SF" onerror="this.style.display='none'">
+                        <span class="player-name">Ricky Pearsall</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$2</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ne.png" class="team-logo" alt="NE" onerror="this.style.display='none'">
+                        <span class="player-name">Rhamondre Stevenson</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$3</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/tb.png" class="team-logo" alt="TB" onerror="this.style.display='none'">
+                        <span class="player-name">Chris Godwin</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/gb.png" class="team-logo" alt="GB" onerror="this.style.display='none'">
+                        <span class="player-name">Tucker Kraft</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/gb.png" class="team-logo" alt="GB" onerror="this.style.display='none'">
+                        <span class="player-name">Jordan Love</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/atl.png" class="team-logo" alt="ATL" onerror="this.style.display='none'">
+                        <span class="player-name">Darnell Mooney</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                </div>
+            </div>
+            <div class="team-card">
+                <div class="team-header">
+                    <div class="team-name">Blood Sweat Beers</div>
+                    <div class="owner-name">Jackie</div>
+                </div>
+                
+                <div class="team-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">13</div>
+                        <div class="stat-label">Players</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$195</div>
+                        <div class="stat-label">Spent</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$5</div>
+                        <div class="stat-label">Remaining</div>
+                    </div>
+                </div>
+                
+                <div class="position-badges">
+                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (1)</span>
+                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (4)</span>
+                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (5)</span>
+                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (1)</span>
+                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
+                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
+                </div>
+                
+                <div class="player-list">
+                    <div class="player-item">
+                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
+                        <span class="player-name">Saquon Barkley</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$51</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/nyj.png" class="team-logo" alt="NYJ" onerror="this.style.display='none'">
+                        <span class="player-name">Garrett Wilson</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$6</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/atl.png" class="team-logo" alt="ATL" onerror="this.style.display='none'">
+                        <span class="player-name">Drake London</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$20</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
+                        <span class="player-name">Jalen Hurts</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$25</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lv.png" class="team-logo" alt="LV" onerror="this.style.display='none'">
+                        <span class="player-name">Ashton Jeanty</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$50</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
+                        <span class="player-name">DJ Moore</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$17</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
+                        <span class="player-name">Evan Engram</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$3</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
+                        <span class="player-name">Minnesota Vikings</span>
+                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
+                        <span class="player-price">$6</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/sea.png" class="team-logo" alt="SEA" onerror="this.style.display='none'">
+                        <span class="player-name">Zach Charbonnet</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$5</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
+                        <span class="player-name">Kaleb Johnson</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$5</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
+                        <span class="player-name">Khalil Shakir</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$5</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/sf.png" class="team-logo" alt="SF" onerror="this.style.display='none'">
+                        <span class="player-name">Jauan Jennings</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/hou.png" class="team-logo" alt="HOU" onerror="this.style.display='none'">
+                        <span class="player-name">Ka'imi Fairbairn</span>
+                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                </div>
+            </div>
+            <div class="team-card">
+                <div class="team-header">
+                    <div class="team-name">Run CMC</div>
+                    <div class="owner-name">Jodi</div>
+                </div>
+                
+                <div class="team-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">17</div>
+                        <div class="stat-label">Players</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$200</div>
+                        <div class="stat-label">Spent</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$0</div>
+                        <div class="stat-label">Remaining</div>
+                    </div>
+                </div>
+                
+                <div class="position-badges">
+                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
+                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
+                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (6)</span>
+                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
+                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
+                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
+                </div>
+                
+                <div class="player-list">
+                    <div class="player-item">
+                        <img src="2025/assets/logos/cin.png" class="team-logo" alt="CIN" onerror="this.style.display='none'">
+                        <span class="player-name">Chase Brown</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$3</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ari.png" class="team-logo" alt="ARI" onerror="this.style.display='none'">
+                        <span class="player-name">Trey McBride</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$14</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/cin.png" class="team-logo" alt="CIN" onerror="this.style.display='none'">
+                        <span class="player-name">Tee Higgins</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$6</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/cin.png" class="team-logo" alt="CIN" onerror="this.style.display='none'">
+                        <span class="player-name">Joe Burrow</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$40</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
+                        <span class="player-name">Caleb Williams</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$8</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ne.png" class="team-logo" alt="NE" onerror="this.style.display='none'">
+                        <span class="player-name">TreVeyon Henderson</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$20</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/tb.png" class="team-logo" alt="TB" onerror="this.style.display='none'">
+                        <span class="player-name">Mike Evans</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$33</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ari.png" class="team-logo" alt="ARI" onerror="this.style.display='none'">
+                        <span class="player-name">James Conner</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$20</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
+                        <span class="player-name">RJ Harvey</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$7</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
+                        <span class="player-name">Denver Broncos</span>
+                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
+                        <span class="player-price">$9</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
+                        <span class="player-name">Colston Loveland</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$6</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ten.png" class="team-logo" alt="TEN" onerror="this.style.display='none'">
+                        <span class="player-name">Calvin Ridley</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$14</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/jax.png" class="team-logo" alt="JAX" onerror="this.style.display='none'">
+                        <span class="player-name">Travis Hunter</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$5</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/tb.png" class="team-logo" alt="TB" onerror="this.style.display='none'">
+                        <span class="player-name">Emeka Egbuka</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$5</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
+                        <span class="player-name">Wil Lutz</span>
+                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
+                        <span class="player-name">Javonte Williams</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$7</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ne.png" class="team-logo" alt="NE" onerror="this.style.display='none'">
+                        <span class="player-name">Stefon Diggs</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$2</span>
+                    </div>
+                </div>
+            </div>
+            <div class="team-card">
+                <div class="team-header">
+                    <div class="team-name">Dewey Pest Control</div>
+                    <div class="owner-name">Lance</div>
+                </div>
+                
+                <div class="team-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">17</div>
+                        <div class="stat-label">Players</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$200</div>
+                        <div class="stat-label">Spent</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$0</div>
+                        <div class="stat-label">Remaining</div>
+                    </div>
+                </div>
+                
+                <div class="position-badges">
+                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
+                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (4)</span>
+                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (7)</span>
+                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
+                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
+                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
+                </div>
+                
+                <div class="player-list">
+                    <div class="player-item">
+                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
+                        <span class="player-name">David Montgomery</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$10</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
+                        <span class="player-name">Zay Flowers</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$21</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
+                        <span class="player-name">Jayden Daniels</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$10</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/jax.png" class="team-logo" alt="JAX" onerror="this.style.display='none'">
+                        <span class="player-name">Brian Thomas Jr.</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$41</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
+                        <span class="player-name">Derrick Henry</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$46</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
+                        <span class="player-name">A.J. Brown</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$32</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
+                        <span class="player-name">Sam LaPorta</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$21</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
+                        <span class="player-name">Pittsburgh Steelers</span>
+                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
+                        <span class="player-price">$5</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
+                        <span class="player-name">Brandon Aubrey</span>
+                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
+                        <span class="player-price">$6</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
+                        <span class="player-name">Jordan Mason</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ten.png" class="team-logo" alt="TEN" onerror="this.style.display='none'">
+                        <span class="player-name">Cam Ward</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
+                        <span class="player-name">George Pickens</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
+                        <span class="player-name">Rashod Bateman</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ind.png" class="team-logo" alt="IND" onerror="this.style.display='none'">
+                        <span class="player-name">Josh Downs</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/cle.png" class="team-logo" alt="CLE" onerror="this.style.display='none'">
+                        <span class="player-name">Jerome Ford</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/gb.png" class="team-logo" alt="GB" onerror="this.style.display='none'">
+                        <span class="player-name">Jayden Reed</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
+                        <span class="player-name">Jake Ferguson</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                </div>
+            </div>
+            <div class="team-card">
+                <div class="team-header">
+                    <div class="team-name">Don't Cook the Lamb</div>
+                    <div class="owner-name">Mitch</div>
+                </div>
+                
+                <div class="team-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">17</div>
+                        <div class="stat-label">Players</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$200</div>
+                        <div class="stat-label">Spent</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$0</div>
+                        <div class="stat-label">Remaining</div>
+                    </div>
+                </div>
+                
+                <div class="position-badges">
+                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
+                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
+                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (6)</span>
+                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
+                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
+                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
+                </div>
+                
+                <div class="player-list">
+                    <div class="player-item">
+                        <img src="2025/assets/logos/hou.png" class="team-logo" alt="HOU" onerror="this.style.display='none'">
+                        <span class="player-name">C.J. Stroud</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$3</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lv.png" class="team-logo" alt="LV" onerror="this.style.display='none'">
+                        <span class="player-name">Brock Bowers</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$9</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/car.png" class="team-logo" alt="CAR" onerror="this.style.display='none'">
+                        <span class="player-name">Chuba Hubbard</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$3</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/sea.png" class="team-logo" alt="SEA" onerror="this.style.display='none'">
+                        <span class="player-name">Cooper Kupp</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$15</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
+                        <span class="player-name">Courtland Sutton</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$25</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/sea.png" class="team-logo" alt="SEA" onerror="this.style.display='none'">
+                        <span class="player-name">Kenneth Walker III</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$28</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
+                        <span class="player-name">DK Metcalf</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$15</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
+                        <span class="player-name">Aaron Jones Sr.</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$12</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
+                        <span class="player-name">Austin Ekeler</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$8</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
+                        <span class="player-name">Jameson Williams</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$12</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
+                        <span class="player-name">Deebo Samuel</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$8</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/den.png" class="team-logo" alt="DEN" onerror="this.style.display='none'">
+                        <span class="player-name">J.K. Dobbins</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$10</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
+                        <span class="player-name">Chris Boswell</span>
+                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/mia.png" class="team-logo" alt="MIA" onerror="this.style.display='none'">
+                        <span class="player-name">Jaylen Waddle</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$12</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
+                        <span class="player-name">Pat Freiermuth</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/mia.png" class="team-logo" alt="MIA" onerror="this.style.display='none'">
+                        <span class="player-name">Tua Tagovailoa</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/jax.png" class="team-logo" alt="JAX" onerror="this.style.display='none'">
+                        <span class="player-name">Jacksonville Jaguars</span>
+                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
+                        <span class="player-price">$37</span>
+                    </div>
+                </div>
+            </div>
+            <div class="team-card">
+                <div class="team-header">
+                    <div class="team-name">THE NIGHTMARE</div>
+                    <div class="owner-name">Raman</div>
+                </div>
+                
+                <div class="team-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">17</div>
+                        <div class="stat-label">Players</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$195</div>
+                        <div class="stat-label">Spent</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$5</div>
+                        <div class="stat-label">Remaining</div>
+                    </div>
+                </div>
+                
+                <div class="position-badges">
+                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (3)</span>
+                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
+                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (5)</span>
+                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
+                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
+                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
+                </div>
+                
+                <div class="player-list">
+                    <div class="player-item">
+                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
+                        <span class="player-name">James Cook</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$33</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lac.png" class="team-logo" alt="LAC" onerror="this.style.display='none'">
+                        <span class="player-name">Ladd McConkey</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$2</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/sf.png" class="team-logo" alt="SF" onerror="this.style.display='none'">
+                        <span class="player-name">George Kittle</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$23</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/sf.png" class="team-logo" alt="SF" onerror="this.style.display='none'">
+                        <span class="player-name">Christian McCaffrey</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$42</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
+                        <span class="player-name">Luther Burden III</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$4</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ari.png" class="team-logo" alt="ARI" onerror="this.style.display='none'">
+                        <span class="player-name">Marvin Harrison Jr.</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$26</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
+                        <span class="player-name">Dak Prescott</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$4</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lar.png" class="team-logo" alt="LAR" onerror="this.style.display='none'">
+                        <span class="player-name">Davante Adams</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$27</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/tb.png" class="team-logo" alt="TB" onerror="this.style.display='none'">
+                        <span class="player-name">Baker Mayfield</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$13</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/jax.png" class="team-logo" alt="JAX" onerror="this.style.display='none'">
+                        <span class="player-name">Travis Etienne Jr.</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$10</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lar.png" class="team-logo" alt="LAR" onerror="this.style.display='none'">
+                        <span class="player-name">Matthew Stafford</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
+                        <span class="player-name">Buffalo Bills</span>
+                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
+                        <span class="player-price">$3</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
+                        <span class="player-name">Dallas Goedert</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
+                        <span class="player-name">Harrison Butker</span>
+                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
+                        <span class="player-name">Kareem Hunt</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/buf.png" class="team-logo" alt="BUF" onerror="this.style.display='none'">
+                        <span class="player-name">Keon Coleman</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$3</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
+                        <span class="player-name">Brian Robinson Jr.</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                </div>
+            </div>
+            <div class="team-card">
+                <div class="team-header">
+                    <div class="team-name">Sanjay's Team</div>
+                    <div class="owner-name">Sanjay</div>
+                </div>
+                
+                <div class="team-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">17</div>
+                        <div class="stat-label">Players</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$168</div>
+                        <div class="stat-label">Spent</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$32</div>
+                        <div class="stat-label">Remaining</div>
+                    </div>
+                </div>
+                
+                <div class="position-badges">
+                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (2)</span>
+                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (5)</span>
+                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (6)</span>
+                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (2)</span>
+                    <span class="position-badge" style="background: #5f82b5; color: white">K (1)</span>
+                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
+                </div>
+                
+                <div class="player-list">
+                    <div class="player-item">
+                        <img src="2025/assets/logos/gb.png" class="team-logo" alt="GB" onerror="this.style.display='none'">
+                        <span class="player-name">Josh Jacobs</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$33</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
+                        <span class="player-name">Isiah Pacheco</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$9</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
+                        <span class="player-name">Jordan Addison</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$2</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/pit.png" class="team-logo" alt="PIT" onerror="this.style.display='none'">
+                        <span class="player-name">Jaylen Warren</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$9</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/no.png" class="team-logo" alt="NO" onerror="this.style.display='none'">
+                        <span class="player-name">Alvin Kamara</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$18</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/was.png" class="team-logo" alt="WAS" onerror="this.style.display='none'">
+                        <span class="player-name">Terry McLaurin</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$20</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/det.png" class="team-logo" alt="DET" onerror="this.style.display='none'">
+                        <span class="player-name">Jake Bates</span>
+                        <span class="player-position" style="background: #5f82b5; color: white">K</span>
+                        <span class="player-price">$2</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lac.png" class="team-logo" alt="LAC" onerror="this.style.display='none'">
+                        <span class="player-name">Justin Herbert</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
+                        <span class="player-name">Mark Andrews</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$10</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/phi.png" class="team-logo" alt="PHI" onerror="this.style.display='none'">
+                        <span class="player-name">DeVonta Smith</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$14</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ind.png" class="team-logo" alt="IND" onerror="this.style.display='none'">
+                        <span class="player-name">Tyler Warren</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$10</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/kc.png" class="team-logo" alt="KC" onerror="this.style.display='none'">
+                        <span class="player-name">Rashee Rice</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$8</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/car.png" class="team-logo" alt="CAR" onerror="this.style.display='none'">
+                        <span class="player-name">Tetairoa McMillan</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$12</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
+                        <span class="player-name">J.J. McCarthy</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/chi.png" class="team-logo" alt="CHI" onerror="this.style.display='none'">
+                        <span class="player-name">D'Andre Swift</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$13</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/lv.png" class="team-logo" alt="LV" onerror="this.style.display='none'">
+                        <span class="player-name">Jakobi Meyers</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$5</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ne.png" class="team-logo" alt="NE" onerror="this.style.display='none'">
+                        <span class="player-name">New England Patriots</span>
+                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
+                        <span class="player-price">$1</span>
+                    </div>
+                </div>
+            </div>
+            <div class="team-card">
+                <div class="team-header">
+                    <div class="team-name">More than A. Thielen</div>
+                    <div class="owner-name">Steve</div>
+                </div>
+                
+                <div class="team-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">8</div>
+                        <div class="stat-label">Players</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$186</div>
+                        <div class="stat-label">Spent</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">$14</div>
+                        <div class="stat-label">Remaining</div>
+                    </div>
+                </div>
+                
+                <div class="position-badges">
+                    <span class="position-badge" style="background: #7b6bb5; color: white">QB (1)</span>
+                    <span class="position-badge" style="background: #5fb572; color: #2a2a2a">RB (2)</span>
+                    <span class="position-badge" style="background: #b5a55f; color: #2a2a2a">WR (3)</span>
+                    <span class="position-badge" style="background: #b5725f; color: #2a2a2a">TE (1)</span>
+                    <span class="position-badge" style="background: #9f5f75; color: white">D/ST (1)</span>
+                </div>
+                
+                <div class="player-list">
+                    <div class="player-item">
+                        <img src="2025/assets/logos/ind.png" class="team-logo" alt="IND" onerror="this.style.display='none'">
+                        <span class="player-name">Jonathan Taylor</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$11</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/tb.png" class="team-logo" alt="TB" onerror="this.style.display='none'">
+                        <span class="player-name">Bucky Irving</span>
+                        <span class="player-position" style="background: #5fb572; color: #2a2a2a">RB</span>
+                        <span class="player-price">$2</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
+                        <span class="player-name">Justin Jefferson</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$44</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/dal.png" class="team-logo" alt="DAL" onerror="this.style.display='none'">
+                        <span class="player-name">CeeDee Lamb</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$45</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/hou.png" class="team-logo" alt="HOU" onerror="this.style.display='none'">
+                        <span class="player-name">Nico Collins</span>
+                        <span class="player-position" style="background: #b5a55f; color: #2a2a2a">WR</span>
+                        <span class="player-price">$41</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
+                        <span class="player-name">Lamar Jackson</span>
+                        <span class="player-position" style="background: #7b6bb5; color: white">QB</span>
+                        <span class="player-price">$28</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/min.png" class="team-logo" alt="MIN" onerror="this.style.display='none'">
+                        <span class="player-name">T.J. Hockenson</span>
+                        <span class="player-position" style="background: #b5725f; color: #2a2a2a">TE</span>
+                        <span class="player-price">$10</span>
+                    </div>
+                    <div class="player-item">
+                        <img src="2025/assets/logos/bal.png" class="team-logo" alt="BAL" onerror="this.style.display='none'">
+                        <span class="player-name">Baltimore Ravens</span>
+                        <span class="player-position" style="background: #9f5f75; color: white">D/ST</span>
+                        <span class="player-price">$5</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Previously, the draft summary was positioned at the bottom of the HTML page, requiring users to scroll to see key statistics and highlights. Additionally, team cards incorrectly displayed the total available players (1002) instead of each team's actual draft count, and the script would crash ungracefully when the API server wasn't running.

This commit relocates the draft summary section to immediately after the header for better visibility, fixes the player count display to show actual drafted players per team, and adds graceful error handling that provides clear instructions to start the API server with "python main.py" when it's not running.