### PR TITLE
maint: Use consistent color palette for NFL team stacking chart

### DIFF
--- a/docs/2025_draft_recap.html
+++ b/docs/2025_draft_recap.html
@@ -2512,7 +2512,7 @@
             });
 
             const teamColors = {};
-            const colors = ['#e74c3c', '#3498db', '#2ecc71', '#f39c12', '#9b59b6', '#1abc9c', '#34495e', '#e67e22', '#95a5a6', '#f1c40f'];
+            const colors = ['#7b6bb5', '#5fb572', '#b5a55f', '#b5725f', '#5f82b5', '#9f5f75', '#8b7355', '#6b8bb5', '#75b55f', '#b58b5f'];
             Array.from(fantasyTeams).forEach((team, i) => {
                 teamColors[team] = colors[i % colors.length];
             });

--- a/utils/generate_draft_recap.py
+++ b/utils/generate_draft_recap.py
@@ -2081,7 +2081,7 @@ def generate_html(
             });
 
             const teamColors = {};
-            const colors = ['#e74c3c', '#3498db', '#2ecc71', '#f39c12', '#9b59b6', '#1abc9c', '#34495e', '#e67e22', '#95a5a6', '#f1c40f'];
+            const colors = ['#7b6bb5', '#5fb572', '#b5a55f', '#b5725f', '#5f82b5', '#9f5f75', '#8b7355', '#6b8bb5', '#75b55f', '#b58b5f'];
             Array.from(fantasyTeams).forEach((team, i) => {
                 teamColors[team] = colors[i % colors.length];
             });


### PR DESCRIPTION
Previous to this commit, the NFL Team Stacking Patterns chart used aggressive, bright colors that were jarring and inconsistent with the design.

This commit updates the NFL stacking chart to use the same muted color palette.