### PR TITLE
feat(viewer): Add League History tab to read-only viewer

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -67,6 +67,7 @@ A local fantasy football auction draft tracking tool with a web-based interface 
 - Uses relative URLs for cross-network compatibility
 - Fetches all data from local read-only API endpoints (same port)
 - Analyst booth transcript in the Draft Analysis tab: scrollable chat-style history with persona headshots, live tail, and infinite scroll for older calls
+- **League History tab** ("The Rafters"): a read-only hall-of-records view of the multi-season archive — champion banners, a 23-season finish grid (regular-season heat + gold titles, click any cell for that team's full end-of-season roster), régime-vs-crown, player loyalty, title droughts, and most-rostered players. Fetched once from `GET /api/v1/league-history`; all leaderboards are derived client-side (styles/scripts are self-contained in `league-history.css` / `league-history.js`)
 
 ### Backend
 **Framework:** FastAPI with Pydantic models  
@@ -87,6 +88,7 @@ A local fantasy football auction draft tracking tool with a web-based interface 
 - `action_log.json` - History of all draft actions for undo capability
 - `config.json` - Application configuration (budgets, min bids, etc.)
 - `player_stats.json` - Player statistics and bye weeks (optional, generated separately)
+- `league_history.json` - Multi-season archive (champions, standings, end-of-season rosters); served read-only and consumed by the viewer's League History tab
 
 ## API Architecture
 
@@ -165,6 +167,10 @@ This allows frontend to handle errors appropriately:
 - Each comment carries a 1-based `seq` (its committed position in the log), which is the cursor clients page against. `seq` is stable because the log is append-only, and is preferred over the second-granular `ts`, which can collide. A torn (un-terminated) trailing line is dropped and never consumes a `seq`.
 - Response is a bare array ordered oldest-first (ascending `seq`); the file is re-read per request, consistent with the stateless design.
 
+**League History Archive:**
+- `GET /api/v1/league-history` returns the league archive resource: a `seasons` array where each season carries its `champion`, `runner_up`, `best_record`, full `standings`, and per-team end-of-season `roster`. Mirrored on both ports (read-only on the viewer).
+- It returns RESTful primitives only — the viewer derives every leaderboard (championship counts, the regular-season finish grid, régime-vs-crown, loyalty, droughts, royalty) on the client. The file is re-read per request and the response is cached client-side since the archive is static.
+
 ## File Structure
 ```
 ffdrafttracker/
@@ -186,7 +192,8 @@ ffdrafttracker/
 │       ├── action_log.py  # ActionLog model
 │       ├── action_logger.py # ActionLogger utility
 │       ├── configuration.py # Configuration model
-│       └── player_stats.py # Player statistics models
+│       ├── player_stats.py # Player statistics models
+│       └── league_history.py # League history archive models
 ├── static/                # Static assets (if needed)
 ├── templates/
 │   ├── index.html         # Main draft application template
@@ -197,7 +204,8 @@ ffdrafttracker/
 │   ├── owners.json        # Owner information
 │   ├── action_log.json    # Complete action history
 │   ├── config.json        # Application configuration
-│   └── player_stats.json  # Player statistics and bye weeks (optional)
+│   ├── player_stats.json  # Player statistics and bye weeks (optional)
+│   └── league_history.json # Multi-season archive for the League History tab
 ├── tests/                 # Test suite
 │   ├── unit/              # Unit tests for models
 │   └── integration/       # Integration tests for file persistence

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ A live auction draft tracking tool for fantasy football leagues. Features a web-
 - Admin: a one-line "Booth" chyron above the Draft Wire; click to expand the last few calls
 - Viewer: a full scrollable transcript in the Draft Analysis tab (headshot panel, infinite scroll for history)
 
+### **League History** (Viewer)
+- A "League History" tab presenting the multi-season archive, served from `GET /api/v1/league-history`
+- Champion banners, a 23-season finish grid (color = regular-season finish, gold = title), régime-vs-crown, player loyalty, title droughts, and most-rostered players
+- Click any grid cell to open that team's full end-of-season roster and step through a manager's seasons
+
 ### **Data Integrity**
 - Optimistic locking prevents concurrent modification conflicts
 - Atomic file operations for crash safety

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -367,6 +367,25 @@
         }
       }
     },
+    "/api/v1/league-history": {
+      "get": {
+        "summary": "Get League History",
+        "description": "Get the league history archive: season-by-season champions, standings,\nand end-of-season rosters (2003-present). Static archive; the viewer derives\nits leaderboards and the finish grid from this resource client-side.",
+        "operationId": "get_league_history_api_v1_league_history_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeagueHistory"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/export/csv": {
       "get": {
         "summary": "Export Draft Csv",
@@ -687,6 +706,29 @@
         ],
         "title": "AdminDraftRequest"
       },
+      "BestRecord": {
+        "properties": {
+          "owner": {
+            "type": "string",
+            "title": "Owner"
+          },
+          "team_name": {
+            "type": "string",
+            "title": "Team Name"
+          },
+          "record": {
+            "type": "string",
+            "title": "Record"
+          }
+        },
+        "type": "object",
+        "required": [
+          "owner",
+          "team_name",
+          "record"
+        ],
+        "title": "BestRecord"
+      },
       "BidRequest": {
         "properties": {
           "owner_id": {
@@ -894,6 +936,24 @@
         ],
         "title": "DraftStateResponse"
       },
+      "Finisher": {
+        "properties": {
+          "owner": {
+            "type": "string",
+            "title": "Owner"
+          },
+          "team_name": {
+            "type": "string",
+            "title": "Team Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "owner",
+          "team_name"
+        ],
+        "title": "Finisher"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -957,6 +1017,19 @@
         ],
         "title": "KickingStats",
         "description": "Kicking statistics for kickers."
+      },
+      "LeagueHistory": {
+        "properties": {
+          "seasons": {
+            "items": {
+              "$ref": "#/components/schemas/SeasonResult"
+            },
+            "type": "array",
+            "title": "Seasons"
+          }
+        },
+        "type": "object",
+        "title": "LeagueHistory"
       },
       "NFLTeam": {
         "type": "string",
@@ -1357,6 +1430,62 @@
         "type": "object",
         "title": "ResetRequest"
       },
+      "RosterEntry": {
+        "properties": {
+          "player_name": {
+            "type": "string",
+            "title": "Player Name"
+          },
+          "position": {
+            "type": "string",
+            "title": "Position",
+            "default": ""
+          },
+          "nfl_team": {
+            "type": "string",
+            "title": "Nfl Team",
+            "default": ""
+          },
+          "slot": {
+            "type": "string",
+            "title": "Slot",
+            "default": ""
+          },
+          "acquisition": {
+            "type": "string",
+            "title": "Acquisition",
+            "default": "DRAFTED"
+          },
+          "draft_price": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Price"
+          },
+          "draft_pick": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Pick"
+          }
+        },
+        "type": "object",
+        "required": [
+          "player_name"
+        ],
+        "title": "RosterEntry",
+        "description": "One player on a team's end-of-season roster."
+      },
       "RushingStats": {
         "properties": {
           "carries": {
@@ -1401,6 +1530,133 @@
         ],
         "title": "RushingStats",
         "description": "Rushing statistics for running backs, wide receivers, and quarterbacks."
+      },
+      "SeasonResult": {
+        "properties": {
+          "year": {
+            "type": "integer",
+            "title": "Year"
+          },
+          "champion": {
+            "$ref": "#/components/schemas/Finisher"
+          },
+          "runner_up": {
+            "$ref": "#/components/schemas/Finisher"
+          },
+          "best_record": {
+            "$ref": "#/components/schemas/BestRecord"
+          },
+          "shared_title": {
+            "type": "boolean",
+            "title": "Shared Title",
+            "default": false
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "manual"
+          },
+          "draft_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Type"
+          },
+          "standings": {
+            "items": {
+              "$ref": "#/components/schemas/TeamSeason"
+            },
+            "type": "array",
+            "title": "Standings"
+          }
+        },
+        "type": "object",
+        "required": [
+          "year",
+          "champion",
+          "runner_up",
+          "best_record"
+        ],
+        "title": "SeasonResult"
+      },
+      "TeamSeason": {
+        "properties": {
+          "team_name": {
+            "type": "string",
+            "title": "Team Name"
+          },
+          "owner": {
+            "type": "string",
+            "title": "Owner"
+          },
+          "wins": {
+            "type": "integer",
+            "title": "Wins",
+            "default": 0
+          },
+          "losses": {
+            "type": "integer",
+            "title": "Losses",
+            "default": 0
+          },
+          "ties": {
+            "type": "integer",
+            "title": "Ties",
+            "default": 0
+          },
+          "points_for": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Points For"
+          },
+          "final_rank": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Final Rank"
+          },
+          "roster": {
+            "items": {
+              "$ref": "#/components/schemas/RosterEntry"
+            },
+            "type": "array",
+            "title": "Roster"
+          }
+        },
+        "type": "object",
+        "required": [
+          "team_name",
+          "owner"
+        ],
+        "title": "TeamSeason",
+        "description": "One team's season: record, final finish, and roster."
       },
       "TeamUpdateRequest": {
         "properties": {

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from src.models import (
     Configuration,
     DraftPick,
     DraftState,
+    LeagueHistory,
     Nominated,
     Owner,
     Player,
@@ -75,6 +76,7 @@ CONFIG_FILE = DATA_DIR / "config.json"
 ACTION_LOG_FILE = DATA_DIR / "action_log.json"
 PLAYER_STATS_FILE = DATA_DIR / "player_stats.json"
 COMMENTS_FILE = DATA_DIR / "analyst-comments.jsonl"
+LEAGUE_HISTORY_FILE = DATA_DIR / "league_history.json"
 
 
 # Request/Response models
@@ -397,6 +399,19 @@ async def _get_player_stats_data():
         return PlayerStatsCollection({})
 
 
+async def _get_league_history_data():
+    """Shared logic for getting the league history archive."""
+    if not LEAGUE_HISTORY_FILE.exists():
+        logger.info("League history file not found, returning empty archive")
+        return LeagueHistory()
+
+    try:
+        return LeagueHistory.model_validate_json(LEAGUE_HISTORY_FILE.read_text())
+    except Exception as e:
+        logger.error(f"Error loading league history: {e}, returning empty archive")
+        return LeagueHistory()
+
+
 async def _get_owners_data():
     """Shared logic for getting all owners."""
     owners_dict = load_owners()
@@ -543,6 +558,14 @@ async def get_comments(
 ):
     """Analyst-booth commentary, ordered oldest-first (ascending `seq`)."""
     return await _get_comments_data(since=since, before=before, limit=limit)
+
+
+@app.get("/api/v1/league-history", response_model=LeagueHistory)
+async def get_league_history():
+    """Get the league history archive: season-by-season champions, standings,
+    and end-of-season rosters (2003-present). Static archive; the viewer derives
+    its leaderboards and the finish grid from this resource client-side."""
+    return await _get_league_history_data()
 
 
 @app.get("/api/v1/export/csv")
@@ -1304,6 +1327,14 @@ async def viewer_get_comments(
 ):
     """Read-only mirror of the admin commentary feed (see `get_comments`)."""
     return await _get_comments_data(since=since, before=before, limit=limit)
+
+
+@viewer_app.get("/api/v1/league-history", response_model=LeagueHistory)
+async def viewer_get_league_history():
+    """Get the league history archive: season-by-season champions, standings,
+    and end-of-season rosters (2003-present). Static archive; the viewer derives
+    its leaderboards and the finish grid from this resource client-side."""
+    return await _get_league_history_data()
 
 
 # Run the application

--- a/static/css/league-history.css
+++ b/static/css/league-history.css
@@ -1,0 +1,201 @@
+/* ==========================================================================
+   League History — "The Rafters"
+   A read-only hall-of-records tab in the team viewer. All selectors are
+   lh- prefixed (the viewer's class namespace is crowded: .track/.fill/.nm/
+   .tag/.insight all exist), and colors reuse the viewer's design tokens.
+   ========================================================================== */
+
+#view-history,
+#lhDrawer,
+#lhTip {
+  --lh-gold: var(--gold);            /* #F4C152 */
+  --lh-gold-hi: #fbd97a;
+  --lh-gold-deep: #9a6e1e;
+  --lh-silver: #b3bcc6;
+  --lh-pewter: #58525f;
+  --lh-pewter-hi: #6d6675;
+  --lh-ink: var(--ice);              /* #F2EEE7 */
+  --lh-ink2: var(--slate);           /* #A09AA6 */
+  --lh-ink3: #757080;
+  --lh-line: var(--line);
+  --lh-line2: var(--line2);
+  --lh-panel: var(--deep);
+  --lh-panel2: var(--deep2);
+  --lh-glow: rgba(244, 193, 82, .5);
+}
+
+/* the pane itself becomes a vertical scrolling study board (overrides .view.active{display:grid}) */
+#view-history.active { display: block; overflow-y: auto; scrollbar-width: thin; scrollbar-color: var(--lh-line2) transparent; }
+.lh-wrap { max-width: 1180px; margin: 0 auto; padding: 4px 22px 120px; font-family: Inter, system-ui, sans-serif; -webkit-font-smoothing: antialiased; font-variant-numeric: tabular-nums; }
+.lh-sec { margin-top: 58px; }
+.lh-sec-head { display: flex; align-items: baseline; gap: 16px; }
+.lh-sec-head h2 { font-family: Anton, sans-serif; font-weight: 400; letter-spacing: .012em; text-transform: uppercase; font-size: clamp(24px, 3vw, 38px); margin: 0; line-height: 1; color: var(--lh-ink); }
+.lh-num { font-family: "Saira Condensed"; font-weight: 700; color: var(--lh-ink3); font-size: 13px; letter-spacing: .2em; }
+.lh-sub { color: var(--lh-ink2); font-size: 14px; max-width: 66ch; line-height: 1.55; margin: 10px 0 24px; }
+.lh-sub b { color: var(--lh-ink); font-weight: 600; }
+.lh-gold-t { color: var(--lh-gold); }
+.lh-silv-t { color: var(--lh-silver); }
+
+/* ---------- masthead ---------- */
+.lh-mast { padding-top: 26px; text-align: center; }
+.lh-eyebrow { font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .34em; text-transform: uppercase; font-size: 12px; color: var(--lh-gold); }
+.lh-title { font-family: Anton, sans-serif; font-weight: 400; text-transform: uppercase; font-size: clamp(40px, 7vw, 84px); line-height: .92; margin: 12px 0 0; letter-spacing: .01em; background: linear-gradient(180deg, #fdfaf3 0%, #d7cdb8 60%, #a89a7d 100%); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+.lh-span { font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .36em; color: var(--lh-ink2); text-transform: uppercase; font-size: 13px; margin-top: 16px; }
+.lh-span b { color: var(--lh-gold); }
+
+/* ---------- rafters / champion banners ---------- */
+.lh-rail { position: relative; margin-top: 44px; border-top: 2px solid var(--lh-line2); box-shadow: 0 1px 0 rgba(0, 0, 0, .6); }
+.lh-rafters { display: flex; justify-content: center; align-items: flex-start; gap: 14px; flex-wrap: wrap; }
+.lh-banner { position: relative; width: 104px; transform-origin: top center; display: flex; flex-direction: column; align-items: center; transform: translateY(-128%); opacity: 0; transition: transform 1.25s cubic-bezier(.16, .72, .29, 1), opacity .7s ease; }
+.lh-banner.in { transform: translateY(0); opacity: 1; }
+.lh-cord { width: 2px; background: linear-gradient(var(--lh-line2), transparent); }
+.lh-cloth { width: 100%; border-radius: 3px 3px 0 0; position: relative; overflow: hidden; background: linear-gradient(160deg, var(--lh-panel), var(--lh-panel2)); border: 1px solid var(--lh-line2); border-top: none; box-shadow: inset 0 1px 0 rgba(255, 255, 255, .05), 0 18px 30px -18px rgba(0, 0, 0, .9); padding: 14px 8px 0; }
+.lh-banner.champ .lh-cloth { background: linear-gradient(160deg, #2a2210, #1a1407); border-color: rgba(244, 193, 82, .4); box-shadow: inset 0 1px 0 rgba(251, 217, 122, .25), 0 0 34px -10px var(--lh-glow); }
+.lh-cloth::after { content: ""; position: absolute; left: 0; right: 0; bottom: -13px; height: 14px; background: inherit; clip-path: polygon(0 0, 100% 0, 100% 40%, 50% 100%, 0 40%); }
+.lh-bname { font-family: Anton; text-transform: uppercase; font-size: 18px; letter-spacing: .02em; line-height: .95; color: var(--lh-ink); }
+.lh-banner.champ .lh-bname { color: var(--lh-gold-hi); }
+.lh-bttl { font-family: Anton; font-size: 40px; line-height: .9; margin-top: 7px; color: var(--lh-silver); }
+.lh-banner.champ .lh-bttl { color: var(--lh-gold); text-shadow: 0 0 18px var(--lh-glow); }
+.lh-blbl { font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .18em; font-size: 9.5px; text-transform: uppercase; color: var(--lh-ink3); margin-top: 1px; }
+.lh-pips { display: flex; gap: 3px; flex-wrap: wrap; justify-content: center; margin-top: 9px; padding-bottom: 11px; }
+.lh-pip { width: 6px; height: 6px; border-radius: 50%; background: var(--lh-gold); box-shadow: 0 0 6px var(--lh-glow); }
+.lh-byr { font-family: "Saira Condensed"; font-weight: 600; font-size: 10px; color: var(--lh-ink3); letter-spacing: .1em; padding-bottom: 10px; }
+
+/* ---------- finish grid ---------- */
+.lh-gridcard { background: linear-gradient(180deg, var(--lh-panel), var(--lh-panel2)); border: 1px solid var(--lh-line); border-radius: 14px; padding: 22px 22px 18px; box-shadow: 0 30px 60px -40px #000; }
+.lh-eras, .lh-grow { display: grid; grid-template-columns: 104px repeat(23, minmax(0, 1fr)); gap: 3px; align-items: center; }
+.lh-eras { grid-template-columns: 104px 9fr 14fr; margin-bottom: 9px; }
+.lh-eseg { font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .2em; text-transform: uppercase; font-size: 10.5px; color: var(--lh-ink3); border-bottom: 1px solid var(--lh-line); padding-bottom: 7px; }
+.lh-eseg.es { color: var(--lh-gold-deep); margin-left: 6px; }
+.lh-grow { margin-bottom: 3px; transition: opacity .2s; }
+.lh-grid:hover .lh-grow:not(.ghead):not(:hover) { opacity: .32; }
+.lh-grow.ghead { margin-bottom: 7px; }
+.lh-yhd { text-align: center; font-family: "Saira Condensed"; font-weight: 600; font-size: 10px; color: var(--lh-ink3); letter-spacing: .02em; }
+.lh-yhd.edge, .lh-cell.edge { margin-left: 6px; }
+.lh-gname { text-align: right; padding-right: 10px; font-family: "Saira Condensed"; font-weight: 700; text-transform: uppercase; letter-spacing: .03em; font-size: 13px; color: var(--lh-ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer; }
+.lh-gname.gone { color: var(--lh-ink3); font-weight: 600; }
+.lh-gname:hover { color: var(--lh-gold-hi); }
+.lh-gname b { color: var(--lh-gold); font-size: 9.5px; margin-left: 5px; letter-spacing: 0; }
+.lh-cell { height: 25px; border-radius: 3px; display: flex; align-items: center; justify-content: center; font-family: "Saira Condensed"; font-weight: 800; font-size: 12px; background: #1a1820; }
+.lh-cell.clk { cursor: pointer; }
+.lh-cell.empty { background: repeating-linear-gradient(45deg, transparent 0 3px, rgba(255, 255, 255, .028) 3px 4px); }
+.lh-cell.champ { background: linear-gradient(155deg, var(--lh-gold-hi), var(--lh-gold-deep)); color: #241a06; box-shadow: 0 0 11px -1px var(--lh-glow); position: relative; z-index: 1; }
+.lh-cell.runner { box-shadow: inset 0 0 0 1.5px rgba(179, 188, 198, .6); }
+.lh-legend { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; margin-top: 16px; font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .04em; font-size: 12px; color: var(--lh-ink3); }
+.lh-lg { display: inline-flex; align-items: center; justify-content: center; width: 14px; height: 14px; border-radius: 3px; vertical-align: -3px; margin-right: 6px; font-size: 9px; color: #241a06; }
+.lh-lg.champ { background: linear-gradient(155deg, var(--lh-gold-hi), var(--lh-gold-deep)); }
+.lh-lg.hi { background: hsl(270 7% 54%); }
+.lh-lg.lo { background: hsl(270 7% 17%); }
+.lh-lg.empty { background: repeating-linear-gradient(45deg, transparent 0 3px, rgba(255, 255, 255, .07) 3px 4px); border: 1px solid var(--lh-line); }
+.lh-ghint { margin-left: auto; color: var(--lh-ink3); }
+
+/* ---------- régime vs crown ---------- */
+.lh-talehead { display: grid; grid-template-columns: 1fr 96px 1fr; gap: 14px; margin-bottom: 12px; }
+.lh-talehead div { font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .2em; text-transform: uppercase; font-size: 12px; }
+.lh-talehead .l { text-align: right; color: var(--lh-silver); }
+.lh-talehead .c { text-align: center; color: var(--lh-ink3); }
+.lh-talehead .r { text-align: left; color: var(--lh-gold); }
+.lh-tale { display: grid; gap: 9px; }
+.lh-tr { display: grid; grid-template-columns: 1fr 96px 1fr; align-items: center; gap: 14px; }
+.lh-tr .who { text-align: center; font-family: "Saira Condensed"; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; font-size: 15px; color: var(--lh-ink); }
+.lh-tr.king .who { color: var(--lh-gold-hi); }
+.lh-barl, .lh-barr { height: 22px; display: flex; align-items: center; }
+.lh-barl { justify-content: flex-end; }
+.lh-barl .b { height: 100%; background: linear-gradient(90deg, #3a4451, var(--lh-silver)); border-radius: 3px 0 0 3px; width: 0; transition: width 1s cubic-bezier(.2, .8, .2, 1); }
+.lh-barr .b { height: 100%; background: linear-gradient(90deg, var(--lh-gold-deep), var(--lh-gold)); border-radius: 0 3px 3px 0; width: 0; transition: width 1s cubic-bezier(.2, .8, .2, 1); }
+.lh-barl .bv, .lh-barr .bv { font-family: Anton; font-size: 16px; color: var(--lh-ink2); padding: 0 8px; }
+.lh-barr .bv { color: var(--lh-gold); }
+
+/* ---------- their guy (loyalty) ---------- */
+.lh-loyal { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+.lh-plq { background: linear-gradient(170deg, var(--lh-panel), var(--lh-panel2)); border: 1px solid var(--lh-line); border-radius: 12px; padding: 18px 16px 16px; position: relative; overflow: hidden; opacity: 0; transform: translateY(14px); transition: .6s; }
+.lh-plq.in { opacity: 1; transform: none; }
+.lh-plq.top { border-color: rgba(244, 193, 82, .45); box-shadow: 0 0 30px -14px var(--lh-glow); }
+.lh-of { font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .2em; text-transform: uppercase; font-size: 11px; color: var(--lh-ink3); }
+.lh-of b { color: var(--lh-ink); }
+.lh-pl { font-family: Anton; text-transform: uppercase; font-size: 22px; line-height: 1.02; margin-top: 9px; color: var(--lh-ink); }
+.lh-plq.top .lh-pl { color: var(--lh-gold-hi); }
+.lh-lmeta { display: flex; align-items: baseline; gap: 8px; margin-top: 11px; }
+.lh-x { font-family: Anton; font-size: 30px; color: var(--lh-gold); }
+.lh-seas { font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .14em; text-transform: uppercase; font-size: 11px; color: var(--lh-ink3); }
+.lh-pos { font-family: "Saira Condensed"; font-weight: 700; font-size: 10px; letter-spacing: .1em; padding: 2px 7px; border-radius: 4px; text-transform: uppercase; position: absolute; top: 16px; right: 14px; }
+.lh-pos.QB { background: color-mix(in srgb, var(--qb) 20%, var(--deep)); color: var(--qb); }
+.lh-pos.RB { background: color-mix(in srgb, var(--rb) 20%, var(--deep)); color: var(--rb); }
+.lh-pos.WR { background: color-mix(in srgb, var(--wr) 20%, var(--deep)); color: var(--wr); }
+.lh-pos.TE { background: color-mix(in srgb, var(--te) 20%, var(--deep)); color: var(--te); }
+.lh-pos.K { background: color-mix(in srgb, var(--k) 20%, var(--deep)); color: var(--k); }
+.lh-pos.DST { background: color-mix(in srgb, var(--dst) 20%, var(--deep)); color: var(--dst); }
+.lh-pos.NA { background: #26232c; color: var(--lh-ink3); }
+
+/* ---------- drought + royalty ---------- */
+.lh-cols { display: grid; grid-template-columns: 1.05fr .95fr; gap: 30px; margin-top: 58px; }
+.lh-row { display: grid; grid-template-columns: 74px 1fr auto; align-items: center; gap: 12px; padding: 7px 0; border-bottom: 1px solid var(--lh-line); }
+.lh-row .lh-nm { font-family: "Saira Condensed"; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; font-size: 14.5px; color: var(--lh-ink); }
+.lh-track { height: 14px; background: #14121a; border-radius: 7px; overflow: hidden; }
+.lh-fill { display: block; height: 100%; width: 0; border-radius: 7px; transition: width 1.1s cubic-bezier(.2, .8, .2, 1); }
+.lh-fill.pew { background: linear-gradient(90deg, #3a3646, #8c89a0); }
+.lh-fill.gold { background: linear-gradient(90deg, var(--lh-gold-deep), var(--lh-gold)); }
+.lh-val { font-family: Anton; font-size: 17px; min-width: 46px; text-align: right; color: var(--lh-ink2); }
+.lh-tag { font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .1em; font-size: 10px; text-transform: uppercase; padding: 2px 7px; border-radius: 4px; }
+.lh-tag.def { background: linear-gradient(180deg, #3a2f12, #241c0a); color: var(--lh-gold-hi); border: 1px solid var(--lh-gold); }
+.lh-foot { margin-top: 14px; font-size: 12.5px; color: var(--lh-ink3); line-height: 1.5; }
+.lh-foot b { color: var(--lh-ink2); }
+.lh-roy .lh-row { grid-template-columns: 150px 1fr 44px; }
+.lh-roy .lh-nm { font-family: "Saira Condensed"; font-weight: 700; font-size: 14px; color: var(--lh-ink); }
+
+/* ---------- hover tooltip ---------- */
+.lh-tip { position: fixed; z-index: 1000; pointer-events: none; max-width: 264px; background: color-mix(in srgb, var(--deep2) 96%, #000); border: 1px solid var(--lh-line2); border-radius: 9px; padding: 11px 13px; box-shadow: 0 18px 40px -18px #000; opacity: 0; transform: translateY(4px); transition: opacity .12s, transform .12s; }
+.lh-tip.on { opacity: 1; transform: none; }
+.lh-tth { font-family: Anton; text-transform: uppercase; font-size: 16px; letter-spacing: .02em; color: var(--lh-ink); }
+.lh-ttteam { font-family: "Saira Condensed"; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; font-size: 12px; color: var(--lh-gold-hi); margin: 2px 0 6px; }
+.lh-ttrow { font-size: 12.5px; color: var(--lh-ink2); line-height: 1.5; }
+.lh-ttrow .ch { color: var(--lh-gold-hi); } .lh-ttrow .ru { color: var(--lh-silver); }
+.lh-ttcta { margin-top: 7px; font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .1em; text-transform: uppercase; font-size: 10px; color: var(--lh-ink3); }
+
+/* ---------- roster drawer ---------- */
+.lh-scrim { position: fixed; inset: 0; background: rgba(6, 5, 9, .66); backdrop-filter: blur(2px); z-index: 1001; opacity: 0; visibility: hidden; transition: opacity .3s, visibility .3s; }
+.lh-scrim.on { opacity: 1; visibility: visible; }
+.lh-drawer { position: fixed; top: 0; right: 0; height: 100%; width: min(430px, 92vw); z-index: 1002; background: linear-gradient(180deg, var(--lh-panel), var(--lh-panel2)); border-left: 1px solid var(--lh-line2); box-shadow: -30px 0 60px -30px #000; transform: translateX(100%); transition: transform .4s cubic-bezier(.22, .68, .3, 1); display: flex; flex-direction: column; overflow: hidden; }
+.lh-drawer.open { transform: none; }
+.lh-drawer-x { position: absolute; top: 14px; right: 14px; z-index: 2; width: 32px; height: 32px; border-radius: 8px; background: var(--lh-panel2); border: 1px solid var(--lh-line); color: var(--lh-ink2); font-size: 20px; line-height: 1; cursor: pointer; }
+.lh-drawer-x:hover { color: var(--lh-ink); border-color: var(--lh-line2); }
+.lh-dhead { padding: 24px 22px 18px; border-bottom: 1px solid var(--lh-line); background: radial-gradient(120% 80% at 100% 0, rgba(244, 193, 82, .08), transparent 60%); }
+.lh-dtop { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.lh-dyear { font-family: Anton; font-size: 44px; line-height: .9; color: var(--lh-gold-hi); }
+.lh-dnav { display: flex; gap: 6px; }
+.lh-dnavbtn { font-family: "Saira Condensed"; font-weight: 700; font-size: 12px; letter-spacing: .04em; color: var(--lh-ink2); background: var(--lh-panel2); border: 1px solid var(--lh-line); border-radius: 7px; padding: 6px 9px; cursor: pointer; min-width: 30px; }
+.lh-dnavbtn:hover:not(:disabled) { color: var(--lh-gold-hi); border-color: var(--lh-gold); }
+.lh-dnavbtn:disabled { opacity: .3; cursor: default; }
+.lh-dteam { font-family: Anton; text-transform: uppercase; font-size: 23px; letter-spacing: .01em; margin-top: 8px; color: var(--lh-ink); }
+.lh-dsub { font-family: "Saira Condensed"; font-weight: 600; font-size: 13.5px; color: var(--lh-ink2); margin-top: 6px; letter-spacing: .02em; }
+.lh-dmgr { color: var(--lh-ink); font-weight: 700; text-transform: uppercase; }
+.lh-dera { font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .16em; text-transform: uppercase; font-size: 10px; color: var(--lh-ink3); margin-top: 7px; }
+.lh-dbadge { font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; font-size: 10.5px; padding: 2px 8px; border-radius: 5px; margin-left: 6px; white-space: nowrap; }
+.lh-dbadge.ch { background: linear-gradient(180deg, #3a2f12, #241c0a); color: var(--lh-gold-hi); border: 1px solid var(--lh-gold); }
+.lh-dbadge.ru { background: var(--lh-panel2); color: var(--lh-silver); border: 1px solid var(--lh-line2); }
+.lh-dbody { flex: 1; overflow-y: auto; padding: 8px 14px 18px; scrollbar-width: thin; scrollbar-color: var(--lh-line2) transparent; }
+.lh-rgrph { font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .18em; text-transform: uppercase; font-size: 10.5px; color: var(--lh-ink3); margin: 18px 8px 8px; padding-bottom: 6px; border-bottom: 1px solid var(--lh-line); }
+.lh-rrow { display: flex; align-items: center; gap: 10px; padding: 7px 8px; border-radius: 7px; }
+.lh-rrow:hover { background: rgba(255, 255, 255, .03); }
+.lh-rpos { font-family: "Saira Condensed"; font-weight: 700; font-size: 10px; letter-spacing: .05em; text-transform: uppercase; width: 34px; text-align: center; padding: 3px 0; border-radius: 4px; flex: none; }
+.lh-rpos.QB { background: color-mix(in srgb, var(--qb) 20%, var(--deep)); color: var(--qb); }
+.lh-rpos.RB { background: color-mix(in srgb, var(--rb) 20%, var(--deep)); color: var(--rb); }
+.lh-rpos.WR { background: color-mix(in srgb, var(--wr) 20%, var(--deep)); color: var(--wr); }
+.lh-rpos.TE { background: color-mix(in srgb, var(--te) 20%, var(--deep)); color: var(--te); }
+.lh-rpos.K { background: color-mix(in srgb, var(--k) 20%, var(--deep)); color: var(--k); }
+.lh-rpos.DST { background: color-mix(in srgb, var(--dst) 20%, var(--deep)); color: var(--dst); }
+.lh-rpos.NA { background: #26232c; color: var(--lh-ink3); }
+.lh-rname { font-weight: 600; font-size: 14px; color: var(--lh-ink); flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.lh-rnfl { font-family: "Saira Condensed"; font-weight: 600; font-size: 11px; color: var(--lh-ink3); letter-spacing: .05em; }
+.lh-dfoot { padding: 11px 16px; border-top: 1px solid var(--lh-line); font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .05em; font-size: 11px; color: var(--lh-ink3); text-align: center; }
+
+.lh-error { color: var(--lh-ink2); text-align: center; padding: 60px 20px; font-size: 15px; }
+
+@media (max-width: 880px) {
+  .lh-cols { grid-template-columns: 1fr; }
+  .lh-loyal { grid-template-columns: repeat(2, 1fr); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .lh-banner, .lh-plq { transition: none; transform: none; opacity: 1; }
+  .lh-fill, .lh-barl .b, .lh-barr .b { transition: none; }
+}

--- a/static/js/league-history.js
+++ b/static/js/league-history.js
@@ -1,0 +1,407 @@
+/* ==========================================================================
+   League History — "The Rafters"  (viewer tab)
+   Fetches the raw season archive from GET /api/v1/league-history and derives
+   every leaderboard + the finish grid client-side, then renders into
+   #view-history. Self-contained: exposes window.LeagueHistory.render().
+   ========================================================================== */
+(function () {
+  "use strict";
+  const API = "/api/v1/league-history";
+  const $ = (s, el) => (el || document).querySelector(s);
+  const ce = (t, c) => { const e = document.createElement(t); if (c) e.className = c; return e; };
+  const ord = (n) => n + (n % 100 >= 11 && n % 100 <= 13 ? "th" : ({ 1: "st", 2: "nd", 3: "rd" }[n % 10] || "th"));
+  const posClass = (p) => (p || "").replace("/", "") || "NA";
+  const skipPlayer = (n) => /D\/ST| - DEF/.test(n);
+
+  let DATA = null, built = false;
+
+  /* ---------------- derive everything from raw seasons ---------------- */
+  function derive(seasonsIn) {
+    const seasons = seasonsIn.slice().sort((a, b) => a.year - b.year);
+    const years = seasons.map((s) => s.year);
+    const latest = years[years.length - 1];
+    const active = new Set(seasons.find((s) => s.year === latest).standings.map((t) => t.owner));
+    const appear = {};
+    seasons.forEach((s) => s.standings.forEach((t) => { appear[t.owner] = (appear[t.owner] || 0) + 1; }));
+    const ironmen = Object.values(appear).filter((c) => c === seasons.length).length;
+
+    const titles = {}, lastTitle = {};
+    seasons.forEach((s) => {
+      const winners = [s.champion.owner];
+      if (s.shared_title) winners.push(s.runner_up.owner);
+      winners.forEach((o) => { titles[o] = (titles[o] || 0) + 1; lastTitle[o] = Math.max(lastTitle[o] || 0, s.year); });
+    });
+    const champions = Object.keys(titles)
+      .map((o) => ({ owner: o, titles: titles[o], last: lastTitle[o], active: active.has(o) }))
+      .sort((a, b) => b.titles - a.titles || b.last - a.last || a.owner.localeCompare(b.owner));
+
+    const best = {};
+    seasons.forEach((s) => { best[s.best_record.owner] = (best[s.best_record.owner] || 0) + 1; });
+    const regime = [...new Set([...Object.keys(titles), ...Object.keys(best)])]
+      .map((o) => ({ owner: o, titles: titles[o] || 0, best: best[o] || 0, active: active.has(o) }))
+      .sort((a, b) => b.best - a.best || b.titles - a.titles);
+
+    // finish grid (regular-season rank) + rosters, in one pass
+    const winpct = (t) => { const g = t.wins + t.losses + t.ties; return g ? (t.wins + 0.5 * t.ties) / g : 0; };
+    const size = {}, cells = {}, rosters = {};
+    seasons.forEach((s) => {
+      size[s.year] = s.standings.length;
+      const champO = s.champion.owner, runO = s.runner_up.owner;
+      const order = s.standings.slice().sort((a, b) => winpct(b) - winpct(a) || (b.points_for || 0) - (a.points_for || 0));
+      order.forEach((t, i) => {
+        const rank = i + 1;
+        const rec = `${t.wins}-${t.losses}` + (t.ties ? `-${t.ties}` : "");
+        const isC = t.owner === champO, isR = t.owner === runO;
+        (cells[t.owner] = cells[t.owner] || {})[s.year] = { r: rank, rec, champ: isC, runner: isR };
+        (rosters[t.owner] = rosters[t.owner] || {})[s.year] = {
+          team: t.team_name, rec, rsRank: rank, final: t.final_rank, champ: isC, runner: isR,
+          src: s.source, draft: s.draft_type,
+          roster: (t.roster || []).map((e) => ({ n: e.player_name, pos: e.position || "", nfl: e.nfl_team || "", slot: e.slot || "" })),
+        };
+      });
+    });
+    const avg = (o) => { const rs = Object.values(cells[o]).map((c) => c.r); return rs.reduce((a, b) => a + b, 0) / rs.length; };
+    const gridRows = Object.keys(cells)
+      .map((o) => ({ owner: o, active: active.has(o), titles: titles[o] || 0, seasons: appear[o], cells: cells[o] }))
+      .sort((a, b) => b.titles - a.titles || b.seasons - a.seasons || avg(a.owner) - avg(b.owner) || a.owner.localeCompare(b.owner));
+
+    // loyalty: the player each manager kept rostering
+    const po = {}, posmap = {};
+    seasons.forEach((s) => s.standings.forEach((t) => {
+      const seen = new Set();
+      (t.roster || []).forEach((e) => {
+        const p = e.player_name;
+        if (seen.has(p) || skipPlayer(p)) return;
+        seen.add(p);
+        po[p] = po[p] || {}; po[p][t.owner] = (po[p][t.owner] || 0) + 1; posmap[p] = e.position || "";
+      });
+    }));
+    const pairs = [];
+    Object.keys(po).forEach((p) => {
+      let bo = null, bc = 0;
+      Object.entries(po[p]).forEach(([o, c]) => { if (c > bc) { bc = c; bo = o; } });
+      if (bc >= 5) pairs.push({ player: p, owner: bo, seasons: bc, pos: posmap[p] || "" });
+    });
+    pairs.sort((a, b) => b.seasons - a.seasons);
+    const seenO = new Set(); const loy = [];
+    pairs.forEach((pr) => { if (!seenO.has(pr.owner)) { seenO.add(pr.owner); loy.push(pr); } });
+    const loyaltyActive = loy.filter((l) => active.has(l.owner)).slice(0, 8);
+    const loyalty = loyaltyActive.length ? loyaltyActive : loy.slice(0, 8);
+
+    // drought BETWEEN titles — active managers who have won at least once
+    const drought = [...active].filter((o) => lastTitle[o])
+      .map((o) => ({ owner: o, since: latest - lastTitle[o] }))
+      .sort((a, b) => b.since - a.since);
+
+    // league royalty: most-rostered NFL players ever
+    const pop = {};
+    seasons.forEach((s) => s.standings.forEach((t) => {
+      const seen = new Set();
+      (t.roster || []).forEach((e) => { const p = e.player_name; if (skipPlayer(p) || seen.has(p)) return; seen.add(p); pop[p] = (pop[p] || 0) + 1; });
+    }));
+    const royalty = Object.entries(pop).map(([player, n]) => ({ player, seasons: n })).sort((a, b) => b.seasons - a.seasons).slice(0, 12);
+
+    return {
+      meta: { years, nSeasons: seasons.length, nManagers: Object.keys(appear).length, ironmen, latest, active },
+      champions, regime, grid: { years, size, rows: gridRows }, loyalty, drought, royalty, rosters,
+    };
+  }
+
+  /* ---------------- scaffold ---------------- */
+  function scaffold(host) {
+    host.innerHTML =
+      `<div class="lh-wrap">
+        <header class="lh-mast">
+          <div class="lh-eyebrow">The League · Est. 2003</div>
+          <h1 class="lh-title">The Rafters</h1>
+          <div class="lh-span" id="lh-span"></div>
+        </header>
+        <div class="lh-rail"><div class="lh-rafters" id="lh-rafters"></div></div>
+
+        <section class="lh-sec">
+          <div class="lh-sec-head"><span class="lh-num">01</span><h2>Season by Season</h2></div>
+          <p class="lh-sub">Twenty-three years of finishes, one square each. <b>Gold is a title, bright is a top year, dark is a lean one</b> — a dynasty reads as a bright row, a slump as a dark stretch. Hover a name to follow one manager; the squares show regular-season finish and gold marks who actually won it. Click any square for that team's full roster.</p>
+          <div class="lh-gridcard">
+            <div class="lh-grid" id="lh-grid"></div>
+            <div class="lh-legend" id="lh-legend"></div>
+          </div>
+        </section>
+
+        <section class="lh-sec">
+          <div class="lh-sec-head"><span class="lh-num">02</span><h2>Régime vs. Crown</h2></div>
+          <p class="lh-sub">Best regular-season record is a régime; a championship is a crown. They don't always go to the same house — the gap between the two columns is the gap between dominant and decisive.</p>
+          <div class="lh-talehead"><div class="l">Best records · régime</div><div class="c">Manager</div><div class="r">Titles · crown</div></div>
+          <div class="lh-tale" id="lh-tale"></div>
+        </section>
+
+        <section class="lh-sec">
+          <div class="lh-sec-head"><span class="lh-num">03</span><h2>Their Guy</h2></div>
+          <p class="lh-sub">Some attachments outlast coaching staffs. These are the players each manager kept coming back for — drafted or stashed, season after season.</p>
+          <div class="lh-loyal" id="lh-loyal"></div>
+        </section>
+
+        <div class="lh-cols">
+          <section class="lh-sec" style="margin-top:0">
+            <div class="lh-sec-head"><span class="lh-num">04</span><h2>Time Since a Title</h2></div>
+            <p class="lh-sub">Every champion eventually waits again — years since each manager who's <b>won at least once</b> last hoisted the trophy.</p>
+            <div id="lh-drought"></div>
+            <p class="lh-foot">Only past champions appear here — <b>win one and the clock starts.</b> Managers still chasing their first aren't on the board.</p>
+          </section>
+          <section class="lh-sec lh-roy" style="margin-top:0">
+            <div class="lh-sec-head"><span class="lh-num">05</span><h2>League Royalty</h2></div>
+            <p class="lh-sub">The NFL names that defined the era — most seasons rostered by <i>anyone</i> in the league.</p>
+            <div id="lh-royalty"></div>
+          </section>
+        </div>
+      </div>`;
+
+    if (!$("#lhDrawer")) {
+      const frag = ce("div");
+      frag.innerHTML =
+        `<div id="lhTip" class="lh-tip"></div>
+         <div id="lhScrim" class="lh-scrim"></div>
+         <aside id="lhDrawer" class="lh-drawer" aria-hidden="true" aria-label="Historical roster">
+           <button id="lhDrawerX" class="lh-drawer-x" aria-label="Close">×</button>
+           <div id="lhDrawerHead" class="lh-dhead"></div>
+           <div id="lhDrawerBody" class="lh-dbody"></div>
+           <div class="lh-dfoot">end-of-season roster · ‹ › or arrow keys to step through seasons</div>
+         </aside>`;
+      while (frag.firstChild) document.body.appendChild(frag.firstChild);
+    }
+  }
+
+  /* ---------------- sections ---------------- */
+  function renderBanners() {
+    $("#lh-span").innerHTML =
+      `<b>${DATA.meta.nSeasons}</b> seasons · <b>${DATA.meta.nManagers}</b> managers · <b>${DATA.meta.ironmen}</b> iron men`;
+    const raf = $("#lh-rafters"), maxT = DATA.champions[0].titles;
+    DATA.champions.forEach((c, i) => {
+      const b = ce("div", "lh-banner" + (c.titles > 1 ? " champ" : ""));
+      const drop = 20 + Math.round((c.titles / maxT) * 30);
+      b.innerHTML =
+        `<div class="lh-cord" style="height:${drop}px"></div>
+         <div class="lh-cloth">
+           <div class="lh-bname">${c.owner}</div>
+           <div class="lh-bttl">${c.titles}</div>
+           <div class="lh-blbl">${c.titles > 1 ? "Titles" : "Title"}</div>
+           <div class="lh-pips">${Array.from({ length: c.titles }).map(() => '<span class="lh-pip"></span>').join("")}</div>
+           <div class="lh-byr">last ${c.last}</div>
+         </div>`;
+      raf.appendChild(b);
+      setTimeout(() => b.classList.add("in"), 300 + i * 170);
+    });
+  }
+
+  function renderGrid() {
+    const G = DATA.grid, GY = G.years, gridEl = $("#lh-grid");
+    const heat = (r, N) => { const t = (N - r) / (N - 1); const L = Math.round(14 + t * 46); return `hsl(270 7% ${L}%)`; };
+    let html =
+      `<div class="lh-eras"><div></div><div class="lh-eseg">Yahoo · ’03–’11</div><div class="lh-eseg es">ESPN · ’12–’25</div></div>` +
+      `<div class="lh-grow ghead"><div class="lh-gname"></div>` +
+      GY.map((y) => `<div class="lh-yhd${y === 2012 ? " edge" : ""}">’${String(y).slice(2)}</div>`).join("") + `</div>`;
+    G.rows.forEach((row) => {
+      const name = `<div class="lh-gname${row.active ? "" : " gone"}" data-o="${row.owner}">${row.owner}` +
+        (row.titles ? `<b>${row.titles}★</b>` : "") + `</div>`;
+      const cellsH = GY.map((y) => {
+        const c = row.cells[y], edge = y === 2012 ? " edge" : "";
+        if (!c) return `<div class="lh-cell empty${edge}"></div>`;
+        if (c.champ) return `<div class="lh-cell champ clk${edge}" data-o="${row.owner}" data-y="${y}">★</div>`;
+        return `<div class="lh-cell clk${c.runner ? " runner" : ""}${edge}" data-o="${row.owner}" data-y="${y}" style="background:${heat(c.r, G.size[y])}"></div>`;
+      }).join("");
+      html += `<div class="lh-grow">${name}${cellsH}</div>`;
+    });
+    gridEl.innerHTML = html;
+    $("#lh-legend").innerHTML =
+      `<span><i class="lh-lg champ">★</i>won the title</span>` +
+      `<span><i class="lh-lg hi"></i>strong season</span>` +
+      `<span><i class="lh-lg lo"></i>down year</span>` +
+      `<span><i class="lh-lg empty"></i>not in the league</span>` +
+      `<span class="lh-ghint">hover a row to trace one manager</span>`;
+    // diagonal cascade reveal
+    const rows = [...gridEl.querySelectorAll(".lh-grow:not(.ghead)")];
+    rows.forEach((rw, ri) => [...rw.querySelectorAll(".lh-cell")].forEach((c, ci) => {
+      c.style.opacity = 0; c.style.transform = "translateY(7px)";
+      requestAnimationFrame(() => {
+        c.style.transition = "opacity .5s ease, transform .5s ease";
+        c.style.transitionDelay = (0.15 + ri * 0.03 + ci * 0.018) + "s";
+        c.style.opacity = ""; c.style.transform = "";
+      });
+    }));
+    wireGrid(gridEl);
+  }
+
+  function renderRegime() {
+    const reg = DATA.regime.filter((r) => r.titles > 0 || r.best >= 2);
+    const maxB = Math.max(...reg.map((r) => r.best), 1), maxC = Math.max(...reg.map((r) => r.titles), 1);
+    const kingBest = reg.slice().sort((a, b) => b.best - a.best)[0].owner;
+    const kingCrown = reg.slice().sort((a, b) => b.titles - a.titles)[0].owner;
+    const tale = $("#lh-tale"); tale.innerHTML = "";
+    reg.forEach((r, i) => {
+      const king = r.owner === kingBest || r.owner === kingCrown;
+      const row = ce("div", "lh-tr" + (king ? " king" : ""));
+      row.innerHTML =
+        `<div class="lh-barl"><span class="bv">${r.best || ""}</span><span class="b"></span></div>` +
+        `<div class="who">${r.owner}</div>` +
+        `<div class="lh-barr"><span class="b"></span><span class="bv">${r.titles || ""}</span></div>`;
+      tale.appendChild(row);
+      setTimeout(() => {
+        $(".lh-barl .b", row).style.width = (r.best / maxB * 46) + "%";
+        $(".lh-barr .b", row).style.width = (r.titles / maxC * 46) + "%";
+      }, 200 + i * 70);
+    });
+  }
+
+  function renderLoyalty() {
+    const loyal = $("#lh-loyal"); loyal.innerHTML = "";
+    DATA.loyalty.forEach((l, i) => {
+      const p = ce("div", "lh-plq" + (l.seasons >= 9 ? " top" : ""));
+      p.innerHTML =
+        `<span class="lh-pos ${posClass(l.pos)}">${l.pos || "—"}</span>` +
+        `<div class="lh-of">${l.owner}<b>'s</b> guy</div>` +
+        `<div class="lh-pl">${l.player}</div>` +
+        `<div class="lh-lmeta"><span class="lh-x" data-n="${l.seasons}">×0</span><span class="lh-seas">seasons rostered</span></div>`;
+      loyal.appendChild(p);
+      const obs = new IntersectionObserver((es) => es.forEach((e) => {
+        if (e.isIntersecting) {
+          p.classList.add("in");
+          let n = 0; const x = $(".lh-x", p);
+          const iv = setInterval(() => { n++; x.textContent = "×" + n; if (n >= l.seasons) clearInterval(iv); }, 70);
+          obs.disconnect();
+        }
+      }), { threshold: 0.4 });
+      setTimeout(() => obs.observe(p), i * 40);
+    });
+  }
+
+  function renderDrought() {
+    const dr = $("#lh-drought"); dr.innerHTML = "";
+    const maxD = Math.max(...DATA.drought.map((d) => d.since), 1);
+    DATA.drought.forEach((d, i) => {
+      const defending = d.since === 0;
+      const row = ce("div", "lh-row");
+      row.innerHTML =
+        `<div class="lh-nm">${d.owner}</div>` +
+        `<div class="lh-track"><span class="lh-fill ${defending ? "gold" : "pew"}"></span></div>` +
+        `<div style="display:flex;gap:9px;align-items:center"><span class="lh-val">${defending ? "★" : d.since}` +
+        `<span style="font-size:10px;color:var(--lh-ink3)"> ${defending ? "now" : "yr"}</span></span>` +
+        (defending ? '<span class="lh-tag def">Defending</span>' : "") + `</div>`;
+      dr.appendChild(row);
+      setTimeout(() => { $(".lh-fill", row).style.width = Math.max(4, d.since / maxD * 100) + "%"; }, 250 + i * 60);
+    });
+  }
+
+  function renderRoyalty() {
+    const ro = $("#lh-royalty"); ro.innerHTML = "";
+    const maxR = DATA.royalty[0].seasons;
+    DATA.royalty.forEach((p, i) => {
+      const row = ce("div", "lh-row");
+      row.innerHTML =
+        `<div class="lh-nm">${p.player}</div>` +
+        `<div class="lh-track"><span class="lh-fill ${i === 0 ? "gold" : "pew"}"></span></div>` +
+        `<div class="lh-val">${p.seasons}</div>`;
+      ro.appendChild(row);
+      setTimeout(() => { $(".lh-fill", row).style.width = (p.seasons / maxR * 100) + "%"; }, 250 + i * 55);
+    });
+  }
+
+  /* ---------------- interactions: grid tooltip + roster drawer ---------------- */
+  function wireGrid(gridEl) {
+    const tip = $("#lhTip");
+    gridEl.addEventListener("mousemove", (e) => {
+      const cell = e.target.closest(".lh-cell.clk");
+      if (!cell) { tip.classList.remove("on"); return; }
+      const o = cell.dataset.o, y = +cell.dataset.y, d = (DATA.rosters[o] || {})[y];
+      if (!d) { tip.classList.remove("on"); return; }
+      const badge = d.champ ? '<b class="ch">✦ Champion</b>' : (d.runner ? '<b class="ru">Runner-up</b>' : "");
+      tip.innerHTML =
+        `<div class="lh-tth">${o} · ${y}</div><div class="lh-ttteam">${d.team}</div>` +
+        `<div class="lh-ttrow">${d.rec} · ${ord(d.rsRank)} of ${DATA.grid.size[y]} in the regular season</div>` +
+        (badge ? `<div class="lh-ttrow">${badge}</div>` : "") +
+        `<div class="lh-ttcta">click for the full roster</div>`;
+      tip.classList.add("on");
+      const pad = 14, w = tip.offsetWidth, h = tip.offsetHeight;
+      let x = e.clientX + pad, top = e.clientY + pad;
+      if (x + w > innerWidth - 8) x = e.clientX - pad - w;
+      if (top + h > innerHeight - 8) top = e.clientY - pad - h;
+      tip.style.left = x + "px"; tip.style.top = top + "px";
+    });
+    gridEl.addEventListener("mouseleave", () => tip.classList.remove("on"));
+    gridEl.addEventListener("click", (e) => {
+      const cell = e.target.closest(".lh-cell.clk");
+      if (cell) { openRoster(cell.dataset.o, +cell.dataset.y); return; }
+      const nm = e.target.closest(".lh-gname");
+      if (nm && nm.dataset.o) {
+        const yrs = Object.keys(DATA.rosters[nm.dataset.o] || {}).map(Number);
+        if (yrs.length) openRoster(nm.dataset.o, Math.max(...yrs));
+      }
+    });
+  }
+
+  const POS_ORDER = { QB: 0, RB: 1, WR: 2, TE: 3, K: 5, "D/ST": 6 };
+  let curO = null, curYears = [];
+
+  function openRoster(o, y) {
+    const d = (DATA.rosters[o] || {})[y]; if (!d) return;
+    curO = o; curYears = Object.keys(DATA.rosters[o]).map(Number).sort((a, b) => a - b);
+    const idx = curYears.indexOf(y);
+    const prev = idx > 0 ? curYears[idx - 1] : null, next = idx < curYears.length - 1 ? curYears[idx + 1] : null;
+    const fin = d.final ? `finished ${ord(d.final)}` : `${ord(d.rsRank)} in the regular season`;
+    const badge = d.champ ? '<span class="lh-dbadge ch">✦ Champion</span>'
+      : (d.runner ? '<span class="lh-dbadge ru">Runner-up</span>' : "");
+    const era = d.draft ? `${(d.src || "").toUpperCase()} · ${d.draft} draft` : "";
+    const bench = (p) => /bench|ir|taxi|reserve/i.test(p.slot || "");
+    const sortP = (a, b) => (POS_ORDER[a.pos] ?? 4) - (POS_ORDER[b.pos] ?? 4) || a.n.localeCompare(b.n);
+    const starters = d.roster.filter((p) => !bench(p)).sort(sortP);
+    const benchers = d.roster.filter(bench).sort(sortP);
+    const line = (p) =>
+      `<div class="lh-rrow"><span class="lh-rpos ${posClass(p.pos)}">${p.pos || "—"}</span>` +
+      `<span class="lh-rname">${p.n}</span><span class="lh-rnfl">${p.nfl || ""}</span></div>`;
+    const grp = (label, arr) => arr.length ? `<div class="lh-rgrph">${label} · ${arr.length}</div>` + arr.map(line).join("") : "";
+    $("#lhDrawerBody").innerHTML = grp("Starting lineup", starters) + grp("Bench & IR", benchers);
+    $("#lhDrawerHead").innerHTML =
+      `<div class="lh-dtop"><div class="lh-dyear">${y}</div>` +
+      `<div class="lh-dnav"><button class="lh-dnavbtn" data-go="${prev ?? ""}" ${prev ? "" : "disabled"}>‹ ${prev || ""}</button>` +
+      `<button class="lh-dnavbtn" data-go="${next ?? ""}" ${next ? "" : "disabled"}>${next || ""} ›</button></div></div>` +
+      `<div class="lh-dteam">${d.team}</div>` +
+      `<div class="lh-dsub"><span class="lh-dmgr">${o}</span> · ${d.rec} · ${fin} ${badge}</div>` +
+      (era ? `<div class="lh-dera">${era}</div>` : "");
+    $("#lhDrawer").querySelectorAll(".lh-dnavbtn").forEach((b) => { b.onclick = () => { if (b.dataset.go) openRoster(o, +b.dataset.go); }; });
+    $("#lhDrawer").classList.add("open"); $("#lhScrim").classList.add("on"); $("#lhDrawer").setAttribute("aria-hidden", "false");
+    $("#lhTip").classList.remove("on");
+  }
+
+  function closeRoster() {
+    $("#lhDrawer").classList.remove("open"); $("#lhScrim").classList.remove("on"); $("#lhDrawer").setAttribute("aria-hidden", "true");
+  }
+
+  function wireDrawerOnce() {
+    $("#lhDrawerX").onclick = closeRoster;
+    $("#lhScrim").onclick = closeRoster;
+    document.addEventListener("keydown", (e) => {
+      if (!$("#lhDrawer").classList.contains("open")) return;
+      if (e.key === "Escape") { closeRoster(); return; }
+      const yr = +($(".lh-dyear") ? $(".lh-dyear").textContent : 0);
+      const i = curYears.indexOf(yr);
+      if (e.key === "ArrowLeft" && i > 0) openRoster(curO, curYears[i - 1]);
+      if (e.key === "ArrowRight" && i >= 0 && i < curYears.length - 1) openRoster(curO, curYears[i + 1]);
+    });
+  }
+
+  /* ---------------- entry ---------------- */
+  function render() {
+    if (built) return;
+    const host = $("#view-history");
+    host.innerHTML = '<div class="lh-error">Loading the archive…</div>';
+    fetch(API).then((r) => r.json()).then((hist) => {
+      const seasons = (hist && hist.seasons) || [];
+      if (!seasons.length) { host.innerHTML = '<div class="lh-error">No league history is available yet.</div>'; built = true; return; }
+      DATA = derive(seasons);
+      scaffold(host);
+      renderBanners(); renderGrid(); renderRegime(); renderLoyalty(); renderDrought(); renderRoyalty();
+      wireDrawerOnce();
+      built = true;
+    }).catch(() => { host.innerHTML = '<div class="lh-error">Couldn’t load the league history.</div>'; });
+  }
+
+  window.LeagueHistory = { render };
+})();

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -10,9 +10,10 @@
     <title>Fantasy Football Team Viewer</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet">
     <link rel="stylesheet" href="/static/css/draft-set-viewer.css?v=4">
+    <link rel="stylesheet" href="/static/css/league-history.css?v=1">
   </head>
   <body>
     <div id="app">
@@ -22,6 +23,7 @@
           <button id="seg-teams" class="active" onclick="showView('teams')">Teams</button>
           <button id="seg-status" onclick="showView('status')">Draft Status</button>
           <button id="seg-analysis" onclick="showView('analysis')">Draft Analysis</button>
+          <button id="seg-history" onclick="showView('history')">League History</button>
         </div>
         <div class="spacer"></div>
         <div class="clocknote" id="clocknote"></div>
@@ -194,9 +196,11 @@
           </div>
         </div>
       </div>
+      <div class="view" id="view-history"></div>
     </div>
     <div id="ptip"></div>
     <div id="vError" class="tb-empty verror-toast"></div>
+    <script src="/static/js/league-history.js?v=1"></script>
     {# Hand-tuned single-line JS below; djlint's reformat collapses a // comment over later code. #}
     {# djlint:off #}
     <script>
@@ -468,13 +472,14 @@
     <div class="id-prog" style="width:${t.picks / TOTAL * 100}%"></div>`;
         }
         function showView(v) {
-            ['teams', 'status', 'analysis'].forEach(x => {
+            ['teams', 'status', 'analysis', 'history'].forEach(x => {
                 document.getElementById('view-' + x).classList.toggle('active', v === x);
                 document.getElementById('seg-' + x).classList.toggle('active', v === x);
             });
             document.getElementById('teamstrip').style.display = v === 'teams' ? 'flex' : 'none';
             if (v === 'status') renderStatusView();
             else if (v === 'analysis') { renderAnalysisView(); boothOnShow(); }
+            else if (v === 'history') LeagueHistory.render();
             else renderTeamsView();
         }
         function activeViewId() { const a = document.querySelector('.view.active'); return a ? a.id : 'view-teams'; }

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -292,6 +292,63 @@ class TestGetEndpoints(TestMainApp):
         assert "CSV generation failed" in response.json()["detail"]
 
 
+class TestLeagueHistoryEndpoint(TestMainApp):
+    """Test GET /api/v1/league-history (the read-only archive resource)."""
+
+    SAMPLE = {
+        "seasons": [
+            {
+                "year": 2024,
+                "champion": {"owner": "Adam", "team_name": "Run CMC"},
+                "runner_up": {"owner": "Greg", "team_name": "Oh no, Romo"},
+                "best_record": {
+                    "owner": "Adam",
+                    "team_name": "Run CMC",
+                    "record": "12-2",
+                },
+                "standings": [
+                    {
+                        "team_name": "Run CMC",
+                        "owner": "Adam",
+                        "wins": 12,
+                        "losses": 2,
+                        "final_rank": 1,
+                        "roster": [{"player_name": "Josh Allen", "position": "QB"}],
+                    }
+                ],
+            }
+        ]
+    }
+
+    @patch("main.LEAGUE_HISTORY_FILE")
+    def test_get_league_history(self, mock_file):
+        """Returns the season archive with standings and rosters intact."""
+        import json
+
+        mock_file.exists.return_value = True
+        mock_file.read_text.return_value = json.dumps(self.SAMPLE)
+
+        response = self.client.get("/api/v1/league-history")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["seasons"]) == 1
+        season = data["seasons"][0]
+        assert season["year"] == 2024
+        assert season["champion"]["owner"] == "Adam"
+        assert season["standings"][0]["roster"][0]["player_name"] == "Josh Allen"
+
+    @patch("main.LEAGUE_HISTORY_FILE")
+    def test_get_league_history_missing_file(self, mock_file):
+        """Returns an empty archive (not a 404/500) when the file is absent."""
+        mock_file.exists.return_value = False
+
+        response = self.client.get("/api/v1/league-history")
+
+        assert response.status_code == 200
+        assert response.json() == {"seasons": []}
+
+
 class TestPostEndpoints(TestMainApp):
     """Test POST endpoints."""
 


### PR DESCRIPTION
## Summary
- Adds a **League History** tab ("The Rafters") to the read-only team viewer, consuming the `league_history.json` archive (23 seasons of champions, standings, and end-of-season rosters) that already shipped in the repo but had no API surface or UI.
- New endpoint `GET /api/v1/league-history` on **both** apps (admin 8175 + viewer 8176), via a shared `_get_league_history_data()` loader + `LEAGUE_HISTORY_FILE` path. Returns the raw `LeagueHistory` resource (RESTful primitives only — no frontend-shaped fields); returns an empty archive instead of erroring when the file is absent.
- The tab **derives every leaderboard client-side** from the raw `seasons`: champion banners, a 23-season regular-season **finish grid** (heat = regular-season finish, gold = title), régime-vs-crown, player loyalty, title droughts, and most-rostered players. Clicking any grid cell opens a **roster drawer** for that team-season with prev/next-season navigation; cells also have hover tooltips.
- Frontend is two self-contained modules (`static/css/league-history.css`, `static/js/league-history.js`) so the large viewer template stays clean. Every CSS selector is `lh-`-prefixed to avoid collisions with the viewer's crowded namespace (`.track/.fill/.nm/.tag/.insight`), and it reuses the viewer's existing color tokens so it looks native.
- Template changes are minimal: Anton webfont, CSS/JS links, a nav button, an empty `#view-history` pane, and a `showView('history')` lazy-render hook.
- Docs updated: `DESIGN.md`, `README.md`, and regenerated `docs/openapi.json`.

## Test plan
- [x] `python -m pytest tests/` — 295 pass (incl. 2 new endpoint tests: populated archive + missing-file → empty archive)
- [x] `ruff check` / `ruff format --check` / `djlint templates/ --check` clean
- [ ] Run `uv run python main.py`, open the viewer at `:8176`, click **League History**
- [ ] Verify the banners drop in, the finish grid renders all 23 seasons (gold = titles, hatched = not-in-league), and hover tooltips show the season summary
- [ ] Click a grid cell → roster drawer opens with that team's full roster; ‹ › / arrow keys step through that manager's seasons; Esc / scrim closes
- [ ] Confirm the other viewer tabs (Teams / Draft Status / Draft Analysis) are unaffected

## Notes
- `data/draft_state.json` was intentionally **not** included (pre-existing live-draft working state, unrelated to this feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)