### PR TITLE
fix(league-history): anonymize untrusted owners; sort active managers first

### DIFF
--- a/data/league_history.json
+++ b/data/league_history.json
@@ -30321,7 +30321,7 @@
         },
         {
           "team_name": "Sweet Sundaes",
-          "owner": "Jen",
+          "owner": "unk4",
           "wins": 5,
           "losses": 8,
           "ties": 0,
@@ -35306,7 +35306,7 @@
         },
         {
           "team_name": "FantasyGirl",
-          "owner": "Elisa",
+          "owner": "unk3",
           "wins": 6,
           "losses": 8,
           "ties": 0,
@@ -36452,7 +36452,7 @@
         },
         {
           "team_name": "Wildcats",
-          "owner": "Jen",
+          "owner": "unk2",
           "wins": 2,
           "losses": 12,
           "ties": 0,
@@ -37986,7 +37986,7 @@
         },
         {
           "team_name": "Thunderbuns 3000",
-          "owner": "Elisa",
+          "owner": "unk1",
           "wins": 8,
           "losses": 6,
           "ties": 0,

--- a/static/js/league-history.js
+++ b/static/js/league-history.js
@@ -63,7 +63,7 @@
     const avg = (o) => { const rs = Object.values(cells[o]).map((c) => c.r); return rs.reduce((a, b) => a + b, 0) / rs.length; };
     const gridRows = Object.keys(cells)
       .map((o) => ({ owner: o, active: active.has(o), titles: titles[o] || 0, seasons: appear[o], cells: cells[o] }))
-      .sort((a, b) => b.titles - a.titles || b.seasons - a.seasons || avg(a.owner) - avg(b.owner) || a.owner.localeCompare(b.owner));
+      .sort((a, b) => (b.active - a.active) || b.titles - a.titles || b.seasons - a.seasons || avg(a.owner) - avg(b.owner) || a.owner.localeCompare(b.owner));
 
     // loyalty: the player each manager kept rostering
     const po = {}, posmap = {};


### PR DESCRIPTION
## Summary
- Reassigns four team-seasons on the viewer's **League History** page from owner attributions we no longer trust to distinct anonymous placeholders (`unk1`–`unk4`): 2004 Thunderbuns 3000 (was Elisa), 2005 Wildcats (was Jen), 2005 FantasyGirl (was Elisa), 2008 Sweet Sundaes (was Jen). This stops the page from making false claims about who managed those teams.
- Uses **distinct** placeholders rather than one shared "Unknown" on purpose: the viewer keys the finish grid by owner-per-year, so collapsing the two 2005 teams into a single "Unknown" would have silently dropped one of them from the grid and made its roster unreachable.
- Changes the **"Season by Season"** finish grid to sort by active-vs-retired as the **primary** key (previously titles-first), then titles → seasons → average finish → name. Current managers now sort above retired ones, so active members are no longer buried beneath retired managers and the placeholder rows.

## Test plan
- [ ] `uv run python main.py`, open the viewer at http://localhost:8176 → **League History** tab
- [ ] In **Season by Season**, confirm the four reassigned teams show as `unk1`–`unk4` (each its own dim, single-year row) — no team is missing, and clicking each cell opens its roster
- [ ] Confirm the no-title section orders active managers (Lance, Sanjay) above retired ones (Angie, Jason, Rob, Leah, th3, Jen, unk*)
- [ ] `python -m pytest tests/unit/models/test_league_history.py` passes (archive invariants / no leaked owners)

## Links
- Follow-up to #47 (league-history archive) / #48 (viewer League History tab)