### PR TITLE
feat(league-history): Add Ledger leaderboard and refine season grid

### DIFF
--- a/static/css/league-history.css
+++ b/static/css/league-history.css
@@ -67,8 +67,20 @@
 .lh-eras { grid-template-columns: 104px 9fr 14fr; margin-bottom: 9px; }
 .lh-eseg { font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .2em; text-transform: uppercase; font-size: 10.5px; color: var(--lh-ink3); border-bottom: 1px solid var(--lh-line); padding-bottom: 7px; }
 .lh-eseg.es { color: var(--lh-gold-deep); margin-left: 6px; }
-.lh-grow { margin-bottom: 3px; transition: opacity .2s; }
-.lh-grid:hover .lh-grow:not(.ghead):not(:hover) { opacity: .32; }
+.lh-grow { margin-bottom: 3px; transition: transform .16s ease; }
+
+/* trace one manager — JS sets .is-active on the row the cursor is actually over
+   (never on dead space). Nothing dims; the active row is simply promoted with a
+   warm spotlight band + a hairline gold rule bracketing it across all 23 years. */
+.lh-grow.is-active { position: relative; z-index: 2; transform: translateY(-1px); }
+.lh-grow.is-active::before {
+  content: ""; position: absolute; inset: -3px -10px; z-index: -1; pointer-events: none;
+  border-radius: 7px;
+  background: linear-gradient(90deg, rgba(244, 193, 82, .11), rgba(244, 193, 82, .035) 72%, transparent);
+  border-top: 1px solid rgba(244, 193, 82, .38);
+  border-bottom: 1px solid rgba(244, 193, 82, .38);
+  box-shadow: 0 10px 26px -14px rgba(0, 0, 0, .85);
+}
 .lh-grow.ghead { margin-bottom: 7px; }
 .lh-yhd { text-align: center; font-family: "Saira Condensed"; font-weight: 600; font-size: 10px; color: var(--lh-ink3); letter-spacing: .02em; }
 .lh-yhd.edge, .lh-cell.edge { margin-left: 6px; }
@@ -76,8 +88,11 @@
 .lh-gname.gone { color: var(--lh-ink3); font-weight: 600; }
 .lh-gname:hover { color: var(--lh-gold-hi); }
 .lh-gname b { color: var(--lh-gold); font-size: 9.5px; margin-left: 5px; letter-spacing: 0; }
-.lh-cell { height: 25px; border-radius: 3px; display: flex; align-items: center; justify-content: center; font-family: "Saira Condensed"; font-weight: 800; font-size: 12px; background: #1a1820; }
+.lh-cell { height: 25px; border-radius: 3px; display: flex; align-items: center; justify-content: center; font-family: "Saira Condensed"; font-weight: 800; font-size: 12px; background: #1a1820; transition: transform .12s ease, box-shadow .12s ease; }
 .lh-cell.clk { cursor: pointer; }
+/* the exact square under the cursor lifts and takes a gold ring — confirms what
+   the tooltip describes and what a click will open. (no looping pulse) */
+.lh-cell.clk:hover { transform: translateY(-2px); z-index: 3; box-shadow: 0 0 0 1px #241a06, 0 0 0 2.5px var(--lh-gold-hi), 0 8px 15px -5px rgba(0, 0, 0, .9); }
 .lh-cell.empty { background: repeating-linear-gradient(45deg, transparent 0 3px, rgba(255, 255, 255, .028) 3px 4px); }
 .lh-cell.champ { background: linear-gradient(155deg, var(--lh-gold-hi), var(--lh-gold-deep)); color: #241a06; box-shadow: 0 0 11px -1px var(--lh-glow); position: relative; z-index: 1; }
 .lh-cell.runner { box-shadow: inset 0 0 0 1.5px rgba(179, 188, 198, .6); }
@@ -127,7 +142,7 @@
 .lh-pos.DST { background: color-mix(in srgb, var(--dst) 20%, var(--deep)); color: var(--dst); }
 .lh-pos.NA { background: #26232c; color: var(--lh-ink3); }
 
-/* ---------- drought + royalty ---------- */
+/* ---------- the ledger + royalty ---------- */
 .lh-cols { display: grid; grid-template-columns: 1.05fr .95fr; gap: 30px; margin-top: 58px; }
 .lh-row { display: grid; grid-template-columns: 74px 1fr auto; align-items: center; gap: 12px; padding: 7px 0; border-bottom: 1px solid var(--lh-line); }
 .lh-row .lh-nm { font-family: "Saira Condensed"; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; font-size: 14.5px; color: var(--lh-ink); }
@@ -136,12 +151,23 @@
 .lh-fill.pew { background: linear-gradient(90deg, #3a3646, #8c89a0); }
 .lh-fill.gold { background: linear-gradient(90deg, var(--lh-gold-deep), var(--lh-gold)); }
 .lh-val { font-family: Anton; font-size: 17px; min-width: 46px; text-align: right; color: var(--lh-ink2); }
-.lh-tag { font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .1em; font-size: 10px; text-transform: uppercase; padding: 2px 7px; border-radius: 4px; }
-.lh-tag.def { background: linear-gradient(180deg, #3a2f12, #241c0a); color: var(--lh-gold-hi); border: 1px solid var(--lh-gold); }
 .lh-foot { margin-top: 14px; font-size: 12.5px; color: var(--lh-ink3); line-height: 1.5; }
 .lh-foot b { color: var(--lh-ink2); }
 .lh-roy .lh-row { grid-template-columns: 150px 1fr 44px; }
 .lh-roy .lh-nm { font-family: "Saira Condensed"; font-weight: 700; font-size: 14px; color: var(--lh-ink); }
+
+/* the ledger — career win rate rendered in the page's win/loss colours:
+   the gold fill is win%, the pewter track showing through is the losses. */
+.lh-led { grid-template-columns: 96px 1fr auto; }
+.lh-led.gone .lh-nm { color: var(--lh-ink3); font-weight: 600; }   /* departed managers, muted like the grid */
+.lh-led-track { height: 16px; border-radius: 8px; overflow: hidden; background: linear-gradient(180deg, #423c4b, var(--lh-pewter)); box-shadow: inset 0 1px 2px rgba(0, 0, 0, .45); }
+.lh-led-fill { display: block; height: 100%; width: 0; border-radius: 8px 0 0 8px; background: linear-gradient(90deg, var(--lh-gold-deep), var(--lh-gold)); box-shadow: 0 0 10px -3px var(--lh-glow); transition: width 1.1s cubic-bezier(.2, .8, .2, 1); }
+.lh-led.top .lh-led-fill { background: linear-gradient(90deg, var(--lh-gold-deep), var(--lh-gold-hi)); }
+.lh-led-val { display: flex; flex-direction: column; align-items: flex-end; line-height: 1; min-width: 62px; }
+.lh-led-pct { font-family: Anton; font-size: 18px; color: var(--lh-ink); }
+.lh-led.gone .lh-led-pct { color: var(--lh-ink2); }
+.lh-led.top .lh-led-pct { color: var(--lh-gold-hi); }
+.lh-led-rec { font-family: "Saira Condensed"; font-weight: 600; font-size: 11px; color: var(--lh-ink3); letter-spacing: .04em; margin-top: 3px; }
 
 /* ---------- hover tooltip ---------- */
 .lh-tip { position: fixed; z-index: 1000; pointer-events: none; max-width: 264px; background: color-mix(in srgb, var(--deep2) 96%, #000); border: 1px solid var(--lh-line2); border-radius: 9px; padding: 11px 13px; box-shadow: 0 18px 40px -18px #000; opacity: 0; transform: translateY(4px); transition: opacity .12s, transform .12s; }
@@ -160,7 +186,8 @@
 .lh-drawer-x { position: absolute; top: 14px; right: 14px; z-index: 2; width: 32px; height: 32px; border-radius: 8px; background: var(--lh-panel2); border: 1px solid var(--lh-line); color: var(--lh-ink2); font-size: 20px; line-height: 1; cursor: pointer; }
 .lh-drawer-x:hover { color: var(--lh-ink); border-color: var(--lh-line2); }
 .lh-dhead { padding: 24px 22px 18px; border-bottom: 1px solid var(--lh-line); background: radial-gradient(120% 80% at 100% 0, rgba(244, 193, 82, .08), transparent 60%); }
-.lh-dtop { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+/* reserve room on the right so the prev/next nav clears the absolute close (×) button */
+.lh-dtop { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding-right: 34px; }
 .lh-dyear { font-family: Anton; font-size: 44px; line-height: .9; color: var(--lh-gold-hi); }
 .lh-dnav { display: flex; gap: 6px; }
 .lh-dnavbtn { font-family: "Saira Condensed"; font-weight: 700; font-size: 12px; letter-spacing: .04em; color: var(--lh-ink2); background: var(--lh-panel2); border: 1px solid var(--lh-line); border-radius: 7px; padding: 6px 9px; cursor: pointer; min-width: 30px; }
@@ -197,5 +224,8 @@
 }
 @media (prefers-reduced-motion: reduce) {
   .lh-banner, .lh-plq { transition: none; transform: none; opacity: 1; }
-  .lh-fill, .lh-barl .b, .lh-barr .b { transition: none; }
+  .lh-fill, .lh-barl .b, .lh-barr .b, .lh-led-fill { transition: none; }
+  /* keep the static spotlight band + ring; drop only the lift and fades */
+  .lh-grow, .lh-cell { transition: none; }
+  .lh-grow.is-active, .lh-cell.clk:hover { transform: none; }
 }

--- a/static/js/league-history.js
+++ b/static/js/league-history.js
@@ -21,9 +21,12 @@
     const years = seasons.map((s) => s.year);
     const latest = years[years.length - 1];
     const active = new Set(seasons.find((s) => s.year === latest).standings.map((t) => t.owner));
-    const appear = {};
-    seasons.forEach((s) => s.standings.forEach((t) => { appear[t.owner] = (appear[t.owner] || 0) + 1; }));
-    const ironmen = Object.values(appear).filter((c) => c === seasons.length).length;
+    const appear = {}, career = {};
+    seasons.forEach((s) => s.standings.forEach((t) => {
+      appear[t.owner] = (appear[t.owner] || 0) + 1;
+      const c = career[t.owner] || (career[t.owner] = { w: 0, l: 0, t: 0 });
+      c.w += t.wins || 0; c.l += t.losses || 0; c.t += t.ties || 0;
+    }));
 
     const titles = {}, lastTitle = {};
     seasons.forEach((s) => {
@@ -46,12 +49,14 @@
     const size = {}, cells = {}, rosters = {};
     seasons.forEach((s) => {
       size[s.year] = s.standings.length;
-      const champO = s.champion.owner, runO = s.runner_up.owner;
+      const champO = s.champion.owner, runO = s.runner_up.owner, shared = !!s.shared_title;
       const order = s.standings.slice().sort((a, b) => winpct(b) - winpct(a) || (b.points_for || 0) - (a.points_for || 0));
       order.forEach((t, i) => {
         const rank = i + 1;
         const rec = `${t.wins}-${t.losses}` + (t.ties ? `-${t.ties}` : "");
-        const isC = t.owner === champO, isR = t.owner === runO;
+        // a shared title makes the runner-up a co-champion, not a runner-up
+        const isC = t.owner === champO || (shared && t.owner === runO);
+        const isR = t.owner === runO && !shared;
         (cells[t.owner] = cells[t.owner] || {})[s.year] = { r: rank, rec, champ: isC, runner: isR };
         (rosters[t.owner] = rosters[t.owner] || {})[s.year] = {
           team: t.team_name, rec, rsRank: rank, final: t.final_rank, champ: isC, runner: isR,
@@ -88,10 +93,12 @@
     const loyaltyActive = loy.filter((l) => active.has(l.owner)).slice(0, 8);
     const loyalty = loyaltyActive.length ? loyaltyActive : loy.slice(0, 8);
 
-    // drought BETWEEN titles — active managers who have won at least once
-    const drought = [...active].filter((o) => lastTitle[o])
-      .map((o) => ({ owner: o, since: latest - lastTitle[o] }))
-      .sort((a, b) => b.since - a.since);
+    // the ledger: career regular-season records, best win rate first (min 3 seasons)
+    const winPct = (c) => { const g = c.w + c.l + c.t; return g ? (c.w + 0.5 * c.t) / g : 0; };
+    const ledger = Object.keys(career)
+      .filter((o) => appear[o] >= 3)
+      .map((o) => ({ owner: o, ...career[o], pct: winPct(career[o]), active: active.has(o) }))
+      .sort((a, b) => b.pct - a.pct || (b.w - b.l) - (a.w - a.l) || a.owner.localeCompare(b.owner));
 
     // league royalty: most-rostered NFL players ever
     const pop = {};
@@ -102,8 +109,8 @@
     const royalty = Object.entries(pop).map(([player, n]) => ({ player, seasons: n })).sort((a, b) => b.seasons - a.seasons).slice(0, 12);
 
     return {
-      meta: { years, nSeasons: seasons.length, nManagers: Object.keys(appear).length, ironmen, latest, active },
-      champions, regime, grid: { years, size, rows: gridRows }, loyalty, drought, royalty, rosters,
+      meta: { years, nSeasons: seasons.length, nManagers: Object.keys(appear).length, latest, active },
+      champions, regime, grid: { years, size, rows: gridRows }, loyalty, ledger, royalty, rosters,
     };
   }
 
@@ -142,10 +149,10 @@
 
         <div class="lh-cols">
           <section class="lh-sec" style="margin-top:0">
-            <div class="lh-sec-head"><span class="lh-num">04</span><h2>Time Since a Title</h2></div>
-            <p class="lh-sub">Every champion eventually waits again — years since each manager who's <b>won at least once</b> last hoisted the trophy.</p>
-            <div id="lh-drought"></div>
-            <p class="lh-foot">Only past champions appear here — <b>win one and the clock starts.</b> Managers still chasing their first aren't on the board.</p>
+            <div class="lh-sec-head"><span class="lh-num">04</span><h2>The Ledger</h2></div>
+            <p class="lh-sub">Every manager's career regular-season record — <b>gold is wins, the rest is losses</b>, best rate on top. Three seasons or more.</p>
+            <div id="lh-ledger"></div>
+            <p class="lh-foot">Regular-season games only — playoffs aren't counted. <b>Ties score as half a win.</b></p>
           </section>
           <section class="lh-sec lh-roy" style="margin-top:0">
             <div class="lh-sec-head"><span class="lh-num">05</span><h2>League Royalty</h2></div>
@@ -173,7 +180,7 @@
   /* ---------------- sections ---------------- */
   function renderBanners() {
     $("#lh-span").innerHTML =
-      `<b>${DATA.meta.nSeasons}</b> seasons · <b>${DATA.meta.nManagers}</b> managers · <b>${DATA.meta.ironmen}</b> iron men`;
+      `<b>${DATA.meta.nSeasons}</b> seasons · <b>${DATA.meta.nManagers}</b> managers · <b>${DATA.champions.length}</b> champions`;
     const raf = $("#lh-rafters"), maxT = DATA.champions[0].titles;
     DATA.champions.forEach((c, i) => {
       const b = ce("div", "lh-banner" + (c.titles > 1 ? " champ" : ""));
@@ -227,6 +234,12 @@
         c.style.opacity = ""; c.style.transform = "";
       });
     }));
+    // once the cascade settles, drop the slow inline reveal transition so the
+    // snappy hover lift (.12s, from the stylesheet) takes over on each cell.
+    const settle = (0.15 + Math.max(0, rows.length - 1) * 0.03 + 22 * 0.018 + 0.55) * 1000;
+    setTimeout(() => rows.forEach((rw) => rw.querySelectorAll(".lh-cell").forEach((c) => {
+      c.style.transition = ""; c.style.transitionDelay = "";
+    })), settle);
     wireGrid(gridEl);
   }
 
@@ -273,20 +286,18 @@
     });
   }
 
-  function renderDrought() {
-    const dr = $("#lh-drought"); dr.innerHTML = "";
-    const maxD = Math.max(...DATA.drought.map((d) => d.since), 1);
-    DATA.drought.forEach((d, i) => {
-      const defending = d.since === 0;
-      const row = ce("div", "lh-row");
+  function renderLedger() {
+    const el = $("#lh-ledger"); el.innerHTML = "";
+    DATA.ledger.forEach((m, i) => {
+      const row = ce("div", "lh-row lh-led" + (m.active ? "" : " gone") + (i === 0 ? " top" : ""));
+      const rec = `${m.w}–${m.l}` + (m.t ? `–${m.t}` : "");
+      const pct = m.pct.toFixed(3).replace(/^0/, ""); // ".597"
       row.innerHTML =
-        `<div class="lh-nm">${d.owner}</div>` +
-        `<div class="lh-track"><span class="lh-fill ${defending ? "gold" : "pew"}"></span></div>` +
-        `<div style="display:flex;gap:9px;align-items:center"><span class="lh-val">${defending ? "★" : d.since}` +
-        `<span style="font-size:10px;color:var(--lh-ink3)"> ${defending ? "now" : "yr"}</span></span>` +
-        (defending ? '<span class="lh-tag def">Defending</span>' : "") + `</div>`;
-      dr.appendChild(row);
-      setTimeout(() => { $(".lh-fill", row).style.width = Math.max(4, d.since / maxD * 100) + "%"; }, 250 + i * 60);
+        `<div class="lh-nm">${m.owner}</div>` +
+        `<div class="lh-led-track"><span class="lh-led-fill"></span></div>` +
+        `<div class="lh-led-val"><span class="lh-led-pct">${pct}</span><span class="lh-led-rec">${rec}</span></div>`;
+      el.appendChild(row);
+      setTimeout(() => { $(".lh-led-fill", row).style.width = (m.pct * 100) + "%"; }, 250 + i * 55);
     });
   }
 
@@ -307,7 +318,18 @@
   /* ---------------- interactions: grid tooltip + roster drawer ---------------- */
   function wireGrid(gridEl) {
     const tip = $("#lhTip");
+    // trace one manager: light up only the row the cursor is genuinely over.
+    // Hovering the gaps, the era strip or the year header marks no row, so nothing
+    // is promoted on dead space. No dimming — just a spotlight on the active row.
+    let activeRow = null;
+    const trace = (row) => {
+      if (row === activeRow) return;
+      if (activeRow) activeRow.classList.remove("is-active");
+      activeRow = row;
+      if (activeRow) activeRow.classList.add("is-active");
+    };
     gridEl.addEventListener("mousemove", (e) => {
+      trace(e.target.closest(".lh-grow:not(.ghead)"));
       const cell = e.target.closest(".lh-cell.clk");
       if (!cell) { tip.classList.remove("on"); return; }
       const o = cell.dataset.o, y = +cell.dataset.y, d = (DATA.rosters[o] || {})[y];
@@ -325,7 +347,7 @@
       if (top + h > innerHeight - 8) top = e.clientY - pad - h;
       tip.style.left = x + "px"; tip.style.top = top + "px";
     });
-    gridEl.addEventListener("mouseleave", () => tip.classList.remove("on"));
+    gridEl.addEventListener("mouseleave", () => { tip.classList.remove("on"); trace(null); });
     gridEl.addEventListener("click", (e) => {
       const cell = e.target.closest(".lh-cell.clk");
       if (cell) { openRoster(cell.dataset.o, +cell.dataset.y); return; }
@@ -397,7 +419,7 @@
       if (!seasons.length) { host.innerHTML = '<div class="lh-error">No league history is available yet.</div>'; built = true; return; }
       DATA = derive(seasons);
       scaffold(host);
-      renderBanners(); renderGrid(); renderRegime(); renderLoyalty(); renderDrought(); renderRoyalty();
+      renderBanners(); renderGrid(); renderRegime(); renderLoyalty(); renderLedger(); renderRoyalty();
       wireDrawerOnce();
       built = true;
     }).catch(() => { host.innerHTML = '<div class="lh-error">Couldn’t load the league history.</div>'; });

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -13,7 +13,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet">
     <link rel="stylesheet" href="/static/css/draft-set-viewer.css?v=4">
-    <link rel="stylesheet" href="/static/css/league-history.css?v=1">
+    <link rel="stylesheet" href="/static/css/league-history.css?v=4">
   </head>
   <body>
     <div id="app">
@@ -200,7 +200,7 @@
     </div>
     <div id="ptip"></div>
     <div id="vError" class="tb-empty verror-toast"></div>
-    <script src="/static/js/league-history.js?v=1"></script>
+    <script src="/static/js/league-history.js?v=4"></script>
     {# Hand-tuned single-line JS below; djlint's reformat collapses a // comment over later code. #}
     {# djlint:off #}
     <script>


### PR DESCRIPTION
## Summary
All changes are scoped to the read-only viewer's **League History** tab.

- **Season-by-Season hover redesign.** Removed the behavior that dimmed the *entire* grid on mouse-enter (an over-broad `.lh-grid:hover` selector that fired on dead space — row gaps, the era strip, the year header). Replaced with a JS-driven `.is-active` row spotlight (gold band + hairline bracketing rule + slight lift) and a per-cell gold ring/lift on hover. No other rows are dimmed; reduced-motion respected.
- **Shared-title bug fix.** The finish grid only marked the primary `champion.owner` as champ and ignored `shared_title`, so the 2022 co-champion (Mitch) showed as "Runner-up". Co-champions now render as gold-★ champs in the grid cell, hover tooltip, and roster drawer badge.
- **Masthead stat.** Swapped the tenure stat ("iron men" / "ever-presents") for **"N champions"** (distinct title-winners), which fits the championship-banner theme; dropped the now-dead tenure computation.
- **Roster drawer fix.** The absolute close (×) button overlapped the prev/next year nav; reserved space on the header row so they no longer collide.
- **New "The Ledger" section** replaces "Time Since a Title" — a career regular-season win-rate leaderboard: a two-tone gold (win%) / pewter (loss%) bar per manager, ranked by win%, for managers with 3+ seasons. Departed managers muted; ties count as half a win.
- Bumped the cache-busting `?v=` strings on `league-history.js`/`.css` to `v=4`.

No API routes changed (this is all client-side derivation from the existing `GET /api/v1/league-history`), so no DESIGN.md/README/OpenAPI updates were needed.

## Test plan
- [ ] Open the viewer (`uv run python main.py` → http://localhost:8176) and go to **League History**.
- [ ] Hover the Season-by-Season grid: gaps / era strip / header no longer dim anything; hovering a row spotlights just that row; hovering a square gives it a gold ring.
- [ ] Verify 2022 shows **both** Adam and Mitch as gold-★ champions (cell, tooltip, and roster drawer badge all say Champion).
- [ ] Masthead reads "23 seasons · 20 managers · 9 champions".
- [ ] Click a grid cell → roster drawer; the × no longer overlaps the prev/next year buttons.
- [ ] "The Ledger" shows 13 managers ranked by win% (Greg `.597` gold at top → Leah `.354`), two-tone bars, departed names muted.
- [ ] `prefers-reduced-motion`: bars/lifts don't animate.