### PR TITLE
feat(league-history): "The Money" auction visualizations in the viewer

### DIFF
--- a/data/auction_prices.json
+++ b/data/auction_prices.json
@@ -8663,6 +8663,978 @@
           }
         ]
       }
+    },
+    "2025": {
+      "owners": {
+        "Adam": [
+          {
+            "player": "Patrick Mahomes",
+            "price": 31,
+            "keeper": false,
+            "espn_id": 3139477
+          },
+          {
+            "player": "Tyreek Hill",
+            "price": 30,
+            "keeper": false,
+            "espn_id": 3116406
+          },
+          {
+            "player": "Jaxon Smith-Njigba",
+            "price": 26,
+            "keeper": false,
+            "espn_id": 4430878
+          },
+          {
+            "player": "Travis Kelce",
+            "price": 19,
+            "keeper": false,
+            "espn_id": 15847
+          },
+          {
+            "player": "Breece Hall",
+            "price": 14,
+            "keeper": true,
+            "espn_id": 4427366
+          },
+          {
+            "player": "Puka Nacua",
+            "price": 13,
+            "keeper": true,
+            "espn_id": 4426515
+          },
+          {
+            "player": "Matthew Golden",
+            "price": 11,
+            "keeper": false,
+            "espn_id": 4701936
+          },
+          {
+            "player": "PHI D/ST",
+            "price": 9,
+            "keeper": false,
+            "espn_id": 26
+          },
+          {
+            "player": "Kyren Williams",
+            "price": 8,
+            "keeper": true,
+            "espn_id": 4430737
+          },
+          {
+            "player": "Tyrone Tracy Jr.",
+            "price": 7,
+            "keeper": false,
+            "espn_id": 4360516
+          },
+          {
+            "player": "Jerry Jeudy",
+            "price": 7,
+            "keeper": false,
+            "espn_id": 4241463
+          },
+          {
+            "player": "Kyle Pitts Sr.",
+            "price": 6,
+            "keeper": false,
+            "espn_id": 4360248
+          },
+          {
+            "player": "Kyler Murray",
+            "price": 5,
+            "keeper": false,
+            "espn_id": 3917315
+          },
+          {
+            "player": "Tyjae Spears",
+            "price": 5,
+            "keeper": false,
+            "espn_id": 4428557
+          },
+          {
+            "player": "Michael Pittman Jr.",
+            "price": 2,
+            "keeper": false,
+            "espn_id": 4035687
+          },
+          {
+            "player": "Ray Davis",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4429501
+          },
+          {
+            "player": "Will Reichard",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4567104
+          }
+        ],
+        "Jodi": [
+          {
+            "player": "Joe Burrow",
+            "price": 40,
+            "keeper": false,
+            "espn_id": 3915511
+          },
+          {
+            "player": "Mike Evans",
+            "price": 33,
+            "keeper": false,
+            "espn_id": 16737
+          },
+          {
+            "player": "TreVeyon Henderson",
+            "price": 20,
+            "keeper": false,
+            "espn_id": 4432710
+          },
+          {
+            "player": "James Conner",
+            "price": 20,
+            "keeper": false,
+            "espn_id": 3045147
+          },
+          {
+            "player": "Trey McBride",
+            "price": 14,
+            "keeper": true,
+            "espn_id": 4361307
+          },
+          {
+            "player": "Calvin Ridley",
+            "price": 14,
+            "keeper": false,
+            "espn_id": 3925357
+          },
+          {
+            "player": "DEN D/ST",
+            "price": 9,
+            "keeper": false,
+            "espn_id": 10
+          },
+          {
+            "player": "Caleb Williams",
+            "price": 8,
+            "keeper": false,
+            "espn_id": 4431611
+          },
+          {
+            "player": "RJ Harvey",
+            "price": 7,
+            "keeper": false,
+            "espn_id": 4568490
+          },
+          {
+            "player": "Javonte Williams",
+            "price": 7,
+            "keeper": false,
+            "espn_id": 4361579
+          },
+          {
+            "player": "Tee Higgins",
+            "price": 6,
+            "keeper": true,
+            "espn_id": 4239993
+          },
+          {
+            "player": "Colston Loveland",
+            "price": 6,
+            "keeper": false,
+            "espn_id": 4723086
+          },
+          {
+            "player": "Travis Hunter",
+            "price": 5,
+            "keeper": false,
+            "espn_id": 4685415
+          },
+          {
+            "player": "Emeka Egbuka",
+            "price": 5,
+            "keeper": false,
+            "espn_id": 4567750
+          },
+          {
+            "player": "Chase Brown",
+            "price": 3,
+            "keeper": true,
+            "espn_id": 4362238
+          },
+          {
+            "player": "Stefon Diggs",
+            "price": 2,
+            "keeper": false,
+            "espn_id": 2976212
+          },
+          {
+            "player": "Wil Lutz",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 2985659
+          }
+        ],
+        "Raman": [
+          {
+            "player": "Christian McCaffrey",
+            "price": 42,
+            "keeper": false,
+            "espn_id": 3117251
+          },
+          {
+            "player": "James Cook",
+            "price": 33,
+            "keeper": true,
+            "espn_id": 4379399
+          },
+          {
+            "player": "Davante Adams",
+            "price": 27,
+            "keeper": false,
+            "espn_id": 16800
+          },
+          {
+            "player": "Marvin Harrison Jr.",
+            "price": 26,
+            "keeper": false,
+            "espn_id": 4432708
+          },
+          {
+            "player": "George Kittle",
+            "price": 23,
+            "keeper": true,
+            "espn_id": 3040151
+          },
+          {
+            "player": "ATL D/ST",
+            "price": 15,
+            "keeper": false,
+            "espn_id": 2
+          },
+          {
+            "player": "Baker Mayfield",
+            "price": 13,
+            "keeper": false,
+            "espn_id": 3052587
+          },
+          {
+            "player": "Travis Etienne Jr.",
+            "price": 10,
+            "keeper": false,
+            "espn_id": 4239996
+          },
+          {
+            "player": "Luther Burden III",
+            "price": 4,
+            "keeper": false,
+            "espn_id": 4685278
+          },
+          {
+            "player": "Dak Prescott",
+            "price": 4,
+            "keeper": false,
+            "espn_id": 2577417
+          },
+          {
+            "player": "BUF D/ST",
+            "price": 3,
+            "keeper": false,
+            "espn_id": 4
+          },
+          {
+            "player": "Keon Coleman",
+            "price": 3,
+            "keeper": false,
+            "espn_id": 4635008
+          },
+          {
+            "player": "Ladd McConkey",
+            "price": 2,
+            "keeper": true,
+            "espn_id": 4612826
+          },
+          {
+            "player": "Matthew Stafford",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 12483
+          },
+          {
+            "player": "Dallas Goedert",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 3121023
+          },
+          {
+            "player": "Harrison Butker",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 3055899
+          },
+          {
+            "player": "Kareem Hunt",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 3059915
+          },
+          {
+            "player": "Brian Robinson Jr.",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4241474
+          }
+        ],
+        "Greg": [
+          {
+            "player": "Jahmyr Gibbs",
+            "price": 43,
+            "keeper": true,
+            "espn_id": 4429795
+          },
+          {
+            "player": "Josh Allen",
+            "price": 40,
+            "keeper": false,
+            "espn_id": 3918298
+          },
+          {
+            "player": "De'Von Achane",
+            "price": 40,
+            "keeper": false,
+            "espn_id": 4429160
+          },
+          {
+            "player": "Malik Nabers",
+            "price": 25,
+            "keeper": true,
+            "espn_id": 4595348
+          },
+          {
+            "player": "Ja'Marr Chase",
+            "price": 11,
+            "keeper": true,
+            "espn_id": 4362628
+          },
+          {
+            "player": "Rome Odunze",
+            "price": 8,
+            "keeper": false,
+            "espn_id": 4431299
+          },
+          {
+            "player": "Quinshon Judkins",
+            "price": 7,
+            "keeper": false,
+            "espn_id": 4685702
+          },
+          {
+            "player": "Tank Bigsby",
+            "price": 4,
+            "keeper": false,
+            "espn_id": 4429013
+          },
+          {
+            "player": "Dalton Kincaid",
+            "price": 3,
+            "keeper": false,
+            "espn_id": 4385690
+          },
+          {
+            "player": "Rhamondre Stevenson",
+            "price": 3,
+            "keeper": false,
+            "espn_id": 4569173
+          },
+          {
+            "player": "Ricky Pearsall",
+            "price": 2,
+            "keeper": false,
+            "espn_id": 4428209
+          },
+          {
+            "player": "Tyler Loop",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4697745
+          },
+          {
+            "player": "DET D/ST",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 11
+          },
+          {
+            "player": "Chris Godwin",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 3116165
+          },
+          {
+            "player": "Tucker Kraft",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4572680
+          },
+          {
+            "player": "Jordan Love",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4036378
+          },
+          {
+            "player": "Darnell Mooney",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4040655
+          }
+        ],
+        "Elisa": [
+          {
+            "player": "Bijan Robinson",
+            "price": 61,
+            "keeper": true,
+            "espn_id": 4430807
+          },
+          {
+            "player": "Amon-Ra St. Brown",
+            "price": 61,
+            "keeper": true,
+            "espn_id": 4374302
+          },
+          {
+            "player": "Omarion Hampton",
+            "price": 19,
+            "keeper": false,
+            "espn_id": 4685382
+          },
+          {
+            "player": "Tony Pollard",
+            "price": 15,
+            "keeper": false,
+            "espn_id": 3916148
+          },
+          {
+            "player": "Xavier Worthy",
+            "price": 11,
+            "keeper": true,
+            "espn_id": 4683062
+          },
+          {
+            "player": "Bo Nix",
+            "price": 9,
+            "keeper": false,
+            "espn_id": 4426338
+          },
+          {
+            "player": "Chris Olave",
+            "price": 6,
+            "keeper": false,
+            "espn_id": 4361370
+          },
+          {
+            "player": "David Njoku",
+            "price": 4,
+            "keeper": false,
+            "espn_id": 3123076
+          },
+          {
+            "player": "HOU D/ST",
+            "price": 4,
+            "keeper": false,
+            "espn_id": 13
+          },
+          {
+            "player": "Cameron Dicker",
+            "price": 3,
+            "keeper": false,
+            "espn_id": 4362081
+          },
+          {
+            "player": "Justin Fields",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4362887
+          },
+          {
+            "player": "Cam Skattebo",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4696981
+          },
+          {
+            "player": "Isaiah Likely",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4361050
+          },
+          {
+            "player": "Jaydon Blue",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4685279
+          },
+          {
+            "player": "Woody Marks",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4429059
+          },
+          {
+            "player": "Jacory Croskey-Merritt",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4575131
+          },
+          {
+            "player": "Keenan Allen",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 15818
+          }
+        ],
+        "Lance": [
+          {
+            "player": "Derrick Henry",
+            "price": 46,
+            "keeper": false,
+            "espn_id": 3043078
+          },
+          {
+            "player": "Brian Thomas Jr.",
+            "price": 41,
+            "keeper": false,
+            "espn_id": 4432773
+          },
+          {
+            "player": "A.J. Brown",
+            "price": 32,
+            "keeper": false,
+            "espn_id": 4047646
+          },
+          {
+            "player": "Zay Flowers",
+            "price": 21,
+            "keeper": true,
+            "espn_id": 4429615
+          },
+          {
+            "player": "Sam LaPorta",
+            "price": 21,
+            "keeper": false,
+            "espn_id": 4430027
+          },
+          {
+            "player": "David Montgomery",
+            "price": 10,
+            "keeper": true,
+            "espn_id": 4035538
+          },
+          {
+            "player": "Jayden Daniels",
+            "price": 10,
+            "keeper": true,
+            "espn_id": 4426348
+          },
+          {
+            "player": "Brandon Aubrey",
+            "price": 6,
+            "keeper": false,
+            "espn_id": 3953687
+          },
+          {
+            "player": "PIT D/ST",
+            "price": 5,
+            "keeper": false,
+            "espn_id": 27
+          },
+          {
+            "player": "Jordan Mason",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4360569
+          },
+          {
+            "player": "Cam Ward",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4688380
+          },
+          {
+            "player": "George Pickens",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4426354
+          },
+          {
+            "player": "Rashod Bateman",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4360939
+          },
+          {
+            "player": "Josh Downs",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4688813
+          },
+          {
+            "player": "Jerome Ford",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4372019
+          },
+          {
+            "player": "Jayden Reed",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4362249
+          },
+          {
+            "player": "Jake Ferguson",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4242355
+          }
+        ],
+        "Steve": [
+          {
+            "player": "CeeDee Lamb",
+            "price": 45,
+            "keeper": false,
+            "espn_id": 4241389
+          },
+          {
+            "player": "Justin Jefferson",
+            "price": 44,
+            "keeper": true,
+            "espn_id": 4262921
+          },
+          {
+            "player": "Nico Collins",
+            "price": 41,
+            "keeper": false,
+            "espn_id": 4258173
+          },
+          {
+            "player": "Lamar Jackson",
+            "price": 28,
+            "keeper": false,
+            "espn_id": 3916387
+          },
+          {
+            "player": "Jonathan Taylor",
+            "price": 11,
+            "keeper": true,
+            "espn_id": 4242335
+          },
+          {
+            "player": "T.J. Hockenson",
+            "price": 10,
+            "keeper": false,
+            "espn_id": 4036133
+          },
+          {
+            "player": "BAL D/ST",
+            "price": 5,
+            "keeper": false,
+            "espn_id": 3
+          },
+          {
+            "player": "Bucky Irving",
+            "price": 2,
+            "keeper": true,
+            "espn_id": 4596448
+          }
+        ],
+        "Jackie": [
+          {
+            "player": "Saquon Barkley",
+            "price": 51,
+            "keeper": true,
+            "espn_id": 3929630
+          },
+          {
+            "player": "Ashton Jeanty",
+            "price": 50,
+            "keeper": false,
+            "espn_id": 4890973
+          },
+          {
+            "player": "Jalen Hurts",
+            "price": 25,
+            "keeper": false,
+            "espn_id": 4040715
+          },
+          {
+            "player": "Drake London",
+            "price": 20,
+            "keeper": true,
+            "espn_id": 4426502
+          },
+          {
+            "player": "DJ Moore",
+            "price": 17,
+            "keeper": false,
+            "espn_id": 3915416
+          },
+          {
+            "player": "Garrett Wilson",
+            "price": 6,
+            "keeper": true,
+            "espn_id": 4569618
+          },
+          {
+            "player": "MIN D/ST",
+            "price": 6,
+            "keeper": false,
+            "espn_id": 21
+          },
+          {
+            "player": "Zach Charbonnet",
+            "price": 5,
+            "keeper": false,
+            "espn_id": 4426385
+          },
+          {
+            "player": "Kaleb Johnson",
+            "price": 5,
+            "keeper": false,
+            "espn_id": 4819231
+          },
+          {
+            "player": "Khalil Shakir",
+            "price": 5,
+            "keeper": false,
+            "espn_id": 4373678
+          },
+          {
+            "player": "Evan Engram",
+            "price": 3,
+            "keeper": false,
+            "espn_id": 3051876
+          },
+          {
+            "player": "Jauan Jennings",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 3886598
+          },
+          {
+            "player": "Ka'imi Fairbairn",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 2971573
+          }
+        ],
+        "Mitch": [
+          {
+            "player": "JAX D/ST",
+            "price": 37,
+            "keeper": false,
+            "espn_id": 15
+          },
+          {
+            "player": "Kenneth Walker III",
+            "price": 28,
+            "keeper": false,
+            "espn_id": 4567048
+          },
+          {
+            "player": "Courtland Sutton",
+            "price": 25,
+            "keeper": false,
+            "espn_id": 3128429
+          },
+          {
+            "player": "Cooper Kupp",
+            "price": 15,
+            "keeper": false,
+            "espn_id": 2977187
+          },
+          {
+            "player": "DK Metcalf",
+            "price": 15,
+            "keeper": false,
+            "espn_id": 4047650
+          },
+          {
+            "player": "Aaron Jones Sr.",
+            "price": 12,
+            "keeper": false,
+            "espn_id": 3042519
+          },
+          {
+            "player": "Jameson Williams",
+            "price": 12,
+            "keeper": false,
+            "espn_id": 4426388
+          },
+          {
+            "player": "Jaylen Waddle",
+            "price": 12,
+            "keeper": false,
+            "espn_id": 4372016
+          },
+          {
+            "player": "J.K. Dobbins",
+            "price": 10,
+            "keeper": false,
+            "espn_id": 4241985
+          },
+          {
+            "player": "Brock Bowers",
+            "price": 9,
+            "keeper": true,
+            "espn_id": 4432665
+          },
+          {
+            "player": "Austin Ekeler",
+            "price": 8,
+            "keeper": false,
+            "espn_id": 3068267
+          },
+          {
+            "player": "Deebo Samuel",
+            "price": 8,
+            "keeper": false,
+            "espn_id": 3126486
+          },
+          {
+            "player": "C.J. Stroud",
+            "price": 3,
+            "keeper": true,
+            "espn_id": 4432577
+          },
+          {
+            "player": "Chuba Hubbard",
+            "price": 3,
+            "keeper": true,
+            "espn_id": 4241416
+          },
+          {
+            "player": "Chris Boswell",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 17372
+          },
+          {
+            "player": "Pat Freiermuth",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4361411
+          },
+          {
+            "player": "Tua Tagovailoa",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4241479
+          }
+        ],
+        "Sanjay": [
+          {
+            "player": "Josh Jacobs",
+            "price": 33,
+            "keeper": true,
+            "espn_id": 4047365
+          },
+          {
+            "player": "Terry McLaurin",
+            "price": 20,
+            "keeper": false,
+            "espn_id": 3121422
+          },
+          {
+            "player": "Alvin Kamara",
+            "price": 18,
+            "keeper": false,
+            "espn_id": 3054850
+          },
+          {
+            "player": "DeVonta Smith",
+            "price": 14,
+            "keeper": false,
+            "espn_id": 4241478
+          },
+          {
+            "player": "D'Andre Swift",
+            "price": 13,
+            "keeper": false,
+            "espn_id": 4259545
+          },
+          {
+            "player": "Tetairoa McMillan",
+            "price": 12,
+            "keeper": false,
+            "espn_id": 4685472
+          },
+          {
+            "player": "Mark Andrews",
+            "price": 10,
+            "keeper": false,
+            "espn_id": 3116365
+          },
+          {
+            "player": "Tyler Warren",
+            "price": 10,
+            "keeper": false,
+            "espn_id": 4431459
+          },
+          {
+            "player": "Isiah Pacheco",
+            "price": 9,
+            "keeper": true,
+            "espn_id": 4361529
+          },
+          {
+            "player": "Jaylen Warren",
+            "price": 9,
+            "keeper": false,
+            "espn_id": 4569987
+          },
+          {
+            "player": "Rashee Rice",
+            "price": 8,
+            "keeper": false,
+            "espn_id": 4428331
+          },
+          {
+            "player": "Jakobi Meyers",
+            "price": 5,
+            "keeper": false,
+            "espn_id": 3916433
+          },
+          {
+            "player": "Jordan Addison",
+            "price": 2,
+            "keeper": true,
+            "espn_id": 4429205
+          },
+          {
+            "player": "Jake Bates",
+            "price": 2,
+            "keeper": false,
+            "espn_id": 4689936
+          },
+          {
+            "player": "Justin Herbert",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4038941
+          },
+          {
+            "player": "J.J. McCarthy",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 4433970
+          },
+          {
+            "player": "NE D/ST",
+            "price": 1,
+            "keeper": false,
+            "espn_id": 22
+          }
+        ]
+      }
     }
   }
 }

--- a/static/css/league-history.css
+++ b/static/css/league-history.css
@@ -177,13 +177,24 @@
 .lh-led-rec { font-family: "Saira Condensed"; font-weight: 600; font-size: 11px; color: var(--lh-ink3); letter-spacing: .04em; margin-top: 3px; }
 
 /* ---------- hover tooltip ---------- */
-.lh-tip { position: fixed; z-index: 1000; pointer-events: none; max-width: 264px; background: color-mix(in srgb, var(--deep2) 96%, #000); border: 1px solid var(--lh-line2); border-radius: 9px; padding: 11px 13px; box-shadow: 0 18px 40px -18px #000; opacity: 0; transform: translateY(4px); transition: opacity .12s, transform .12s; }
+.lh-tip { position: fixed; z-index: 1000; pointer-events: none; max-width: 320px; background: color-mix(in srgb, var(--deep2) 96%, #000); border: 1px solid var(--lh-line2); border-radius: 9px; padding: 11px 13px; box-shadow: 0 18px 40px -18px #000; opacity: 0; transform: translateY(4px); transition: opacity .12s, transform .12s; }
 .lh-tip.on { opacity: 1; transform: none; }
 .lh-tth { font-family: Anton; text-transform: uppercase; font-size: 16px; letter-spacing: .02em; color: var(--lh-ink); }
 .lh-ttteam { font-family: "Saira Condensed"; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; font-size: 12px; color: var(--lh-gold-hi); margin: 2px 0 6px; }
 .lh-ttrow { font-size: 12.5px; color: var(--lh-ink2); line-height: 1.5; }
 .lh-ttrow .ch { color: var(--lh-gold-hi); } .lh-ttrow .ru { color: var(--lh-silver); }
 .lh-ttcta { margin-top: 7px; font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .1em; text-transform: uppercase; font-size: 10px; color: var(--lh-ink3); }
+/* per-season detail lines (royalty + dropped-player hovers) */
+.lh-ttline { font-size: 12px; color: var(--lh-ink2); line-height: 1.55; }
+.lh-ttteam + .lh-ttline { margin-top: 5px; }
+.lh-ttline b { color: var(--lh-ink); font-weight: 700; }
+.lh-ttline .ch { color: var(--lh-gold-hi); }
+.lh-ttline .ru { color: var(--lh-silver); }
+.lh-tty { display: inline-block; min-width: 26px; color: var(--lh-ink3); font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .02em; }
+/* rows that reveal a hover tooltip */
+.lh-hov { cursor: default; }
+.lh-burn.lh-hov:hover { background: rgba(255, 255, 255, .025); }
+.lh-roy .lh-row.lh-hov:hover { background: rgba(255, 255, 255, .025); }
 
 /* ---------- roster drawer ---------- */
 .lh-scrim { position: fixed; inset: 0; background: rgba(6, 5, 9, .66); backdrop-filter: blur(2px); z-index: 1001; opacity: 0; visibility: hidden; transition: opacity .3s, visibility .3s; }

--- a/static/css/league-history.css
+++ b/static/css/league-history.css
@@ -22,6 +22,13 @@
   --lh-panel: var(--deep);
   --lh-panel2: var(--deep2);
   --lh-glow: rgba(244, 193, 82, .5);
+  /* Part II · The Money — ember (dollars to ash) + green (dollars that survived) */
+  --lh-ember: #f0673b;
+  --lh-ember-hi: #f7a23a;
+  --lh-char: #5a4a45;
+  --lh-char-deep: #2b2422;
+  --lh-money: var(--turf);           /* #34C06C */
+  --lh-money-hi: #5fe39a;
 }
 
 /* the pane itself becomes a vertical scrolling study board (overrides .view.active{display:grid}) */
@@ -216,16 +223,115 @@
 .lh-rnfl { font-family: "Saira Condensed"; font-weight: 600; font-size: 11px; color: var(--lh-ink3); letter-spacing: .05em; }
 .lh-dfoot { padding: 11px 16px; border-top: 1px solid var(--lh-line); font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .05em; font-size: 11px; color: var(--lh-ink3); text-align: center; }
 
+/* ======================= Part II · The Money ======================= */
+/* act break */
+.lh-act { display: flex; align-items: center; gap: 18px; margin-top: 86px; }
+.lh-actrule { flex: 1; height: 1px; background: linear-gradient(90deg, transparent, var(--lh-line2)); }
+.lh-act .lh-actrule:last-child { background: linear-gradient(90deg, var(--lh-line2), transparent); }
+.lh-acttext { font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .34em; text-transform: uppercase; font-size: 12px; color: var(--lh-gold); white-space: nowrap; }
+.lh-actsub { text-align: center; color: var(--lh-ink2); font-size: 13.5px; line-height: 1.5; max-width: 64ch; margin: 14px auto 0; }
+
+/* ---------- 06 · sunk costs ---------- */
+.lh-sunkcard { background: linear-gradient(180deg, var(--lh-panel), var(--lh-panel2)); border: 1px solid var(--lh-line); border-radius: 14px; padding: 8px 20px; box-shadow: 0 30px 60px -40px #000; }
+.lh-burn { display: grid; grid-template-columns: 88px minmax(0, 1fr) auto; align-items: center; gap: 16px; padding: 11px 0; border-bottom: 1px solid var(--lh-line); }
+.lh-burn:last-child { border-bottom: none; }
+.lh-bmid { min-width: 0; }
+.lh-bowner { font-family: "Saira Condensed"; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; font-size: 14px; color: var(--lh-ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.lh-bplayer { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 9px; min-width: 0; margin-bottom: 7px; font-family: "Saira Condensed"; font-weight: 600; font-size: 14.5px; color: var(--lh-ink2); }
+.lh-bkeep { font-family: "Saira Condensed"; font-weight: 700; font-size: 8.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--lh-ink3); border: 1px solid var(--lh-line2); border-radius: 4px; padding: 1px 5px; }
+.lh-bstat { font-family: "Saira Condensed"; font-weight: 700; font-size: 9px; letter-spacing: .12em; text-transform: uppercase; padding: 1px 6px; border-radius: 4px; }
+.lh-bstat.gone { background: color-mix(in srgb, var(--lh-ember) 18%, var(--deep)); color: var(--lh-ember-hi); }
+.lh-bstat.traded { background: color-mix(in srgb, var(--lh-gold) 16%, var(--deep)); color: var(--lh-gold-hi); }
+.lh-btrack { height: 12px; background: #14110f; border-radius: 6px; overflow: hidden; }
+.lh-bfill { display: block; height: 100%; width: 0; border-radius: 6px; transition: width 1.1s cubic-bezier(.2, .8, .2, 1); }
+.lh-burn.gone .lh-bfill { background: linear-gradient(90deg, var(--lh-ember-hi), var(--lh-ember) 46%, var(--lh-char) 100%); }
+.lh-burn.traded .lh-bfill { background: linear-gradient(90deg, var(--lh-gold), var(--lh-ember-hi)); }
+.lh-bend { display: flex; align-items: center; gap: 14px; justify-self: end; }
+.lh-bprice { font-family: Anton; font-size: 24px; line-height: 1; color: var(--lh-ember-hi); min-width: 52px; text-align: right; }
+.lh-brec { display: flex; align-items: center; gap: 9px; font-family: "Saira Condensed"; font-weight: 700; font-size: 13px; letter-spacing: .03em; color: var(--lh-ink3); min-width: 150px; }
+.lh-btag { font-family: "Saira Condensed"; font-weight: 700; font-size: 9.5px; letter-spacing: .1em; text-transform: uppercase; padding: 2px 8px; border-radius: 5px; }
+.lh-btag.won { background: linear-gradient(180deg, #16331f, #0e2415); color: var(--lh-money-hi); border: 1px solid color-mix(in srgb, var(--lh-money) 55%, transparent); box-shadow: 0 0 14px -4px var(--lh-money); }
+.lh-btag.champ { background: linear-gradient(180deg, #3a2f12, #241c0a); color: var(--lh-gold-hi); border: 1px solid var(--lh-gold); box-shadow: 0 0 14px -4px var(--lh-glow); }
+
+/* ---------- 07 · the big board ---------- */
+.lh-boardcard { background: linear-gradient(180deg, var(--lh-panel), var(--lh-panel2)); border: 1px solid var(--lh-line); border-radius: 14px; padding: 16px 18px 18px; box-shadow: 0 30px 60px -40px #000; }
+.lh-movers { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; padding-bottom: 14px; margin-bottom: 6px; border-bottom: 1px solid var(--lh-line); }
+.lh-mvlbl { font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .2em; text-transform: uppercase; font-size: 10px; color: var(--lh-ink3); margin-right: 4px; }
+.lh-mv { font-family: "Saira Condensed"; font-weight: 600; font-size: 12px; letter-spacing: .02em; background: var(--lh-panel2); border: 1px solid var(--lh-line); border-radius: 20px; padding: 4px 11px; cursor: pointer; transition: border-color .14s, transform .14s; }
+.lh-mv b { font-weight: 800; }
+.lh-mv.up { color: var(--lh-money-hi); }
+.lh-mv.down { color: var(--lh-ember-hi); }
+.lh-mv:hover { transform: translateY(-1px); border-color: var(--lh-line2); }
+.lh-board { width: 100%; }
+.bb-svg { width: 100%; height: auto; display: block; }
+.bb-grid { stroke: var(--lh-line); stroke-width: 1; }
+.bb-yl, .bb-xl { font-family: "Saira Condensed"; font-weight: 600; font-size: 12px; fill: var(--lh-ink3); }
+.bb-line { fill: none; stroke-width: 2.4; stroke-linejoin: round; stroke-linecap: round; }
+.bb-dot { cursor: pointer; transition: r .12s ease; }
+.bb-dot:hover { r: 5.5; }
+.bb-end { font-family: "Saira Condensed"; font-weight: 800; font-size: 13px; letter-spacing: .02em; }
+.lh-boardempty { padding: 80px 20px; text-align: center; color: var(--lh-ink3); font-size: 14px; }
+.lh-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.lh-chip { display: inline-flex; align-items: center; gap: 7px; font-family: "Saira Condensed"; font-weight: 600; font-size: 12.5px; color: var(--lh-ink2); background: var(--lh-panel2); border: 1px solid var(--lh-line); border-radius: 8px; padding: 5px 10px; cursor: pointer; transition: border-color .14s, color .14s, background .14s; }
+.lh-chip i { font-style: normal; font-family: Anton; font-size: 12px; color: var(--lh-ink3); }
+.lh-chipdot { width: 9px; height: 9px; border-radius: 50%; }
+.lh-chip:hover { color: var(--lh-ink); border-color: var(--lh-line2); }
+.lh-chip.on { color: var(--lh-ink); background: color-mix(in srgb, var(--lh-gold) 12%, var(--lh-panel2)); border-color: color-mix(in srgb, var(--lh-gold) 55%, transparent); }
+.lh-chip.on i { color: var(--lh-gold-hi); }
+
+/* ---------- 08 · maestro & wizard (the manager map) ---------- */
+.lh-quad { position: relative; background: linear-gradient(180deg, var(--lh-panel), var(--lh-panel2)); border: 1px solid var(--lh-line); border-radius: 14px; padding: 18px 22px 14px 46px; box-shadow: 0 30px 60px -40px #000; }
+.lh-plot { position: relative; height: clamp(340px, 42vw, 470px); margin: 6px 8px 30px 6px; border-left: 1px solid var(--lh-line2); border-bottom: 1px solid var(--lh-line2); }
+.lh-qzone { position: absolute; overflow: hidden; }
+.lh-qzone span { position: absolute; font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; font-size: 11px; padding: 7px 10px; opacity: .82; }
+.lh-qzone.maestro { background: linear-gradient(225deg, color-mix(in srgb, var(--lh-gold) 11%, transparent), transparent 65%); }
+.lh-qzone.maestro span { top: 0; right: 0; color: var(--lh-gold-hi); }
+.lh-qzone.wizard { background: linear-gradient(315deg, color-mix(in srgb, var(--turf) 9%, transparent), transparent 65%); }
+.lh-qzone.wizard span { top: 0; left: 0; color: var(--lh-money-hi); }
+.lh-qzone.forget { background: linear-gradient(135deg, color-mix(in srgb, var(--lh-pewter) 16%, transparent), transparent 65%); }
+.lh-qzone.forget span { bottom: 0; right: 0; color: var(--lh-silver); }
+.lh-qzone.adrift span { bottom: 0; left: 0; color: var(--lh-ink3); }
+.lh-qx, .lh-qy { position: absolute; pointer-events: none; }
+.lh-qx { top: 0; bottom: 0; width: 0; border-left: 1px dashed var(--lh-line2); }
+.lh-qy { left: 0; right: 0; height: 0; border-top: 1px dashed var(--lh-line2); }
+.lh-qx span, .lh-qy span { position: absolute; font-family: "Saira Condensed"; font-weight: 600; font-size: 9.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--lh-ink3); white-space: nowrap; }
+.lh-qx span { top: -16px; left: 4px; }
+.lh-qy span { left: 4px; top: -14px; }
+.lh-qpt { position: absolute; transform: translate(-50%, -50%); display: flex; flex-direction: column; align-items: center; gap: 3px; cursor: pointer; z-index: 2; }
+.lh-qpt.hot { z-index: 5; }
+.lh-qdot { display: block; border-radius: 50%; transition: transform .14s ease; }
+.lh-qpt.hot .lh-qdot { transform: scale(1.12); }
+.lh-qname { font-family: "Saira Condensed"; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; font-size: 11px; color: var(--lh-ink2); text-shadow: 0 1px 3px #000; white-space: nowrap; }
+.lh-qpt.hot .lh-qname { color: var(--lh-ink); }
+.lh-qaxx { position: absolute; left: 46px; right: 22px; bottom: 12px; text-align: center; font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; font-size: 10.5px; color: var(--lh-ink3); }
+.lh-qaxy { position: absolute; left: 4px; top: 50%; transform: rotate(-90deg) translateX(50%); transform-origin: left center; font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; font-size: 10.5px; color: var(--lh-ink3); white-space: nowrap; }
+.lh-qcorner { position: absolute; left: 14px; font-family: "Saira Condensed"; font-weight: 600; font-size: 10px; color: var(--lh-ink3); }
+.lh-qcorner.tl { top: 16px; }
+.lh-qcorner.bl { bottom: 46px; }
+
 .lh-error { color: var(--lh-ink2); text-align: center; padding: 60px 20px; font-size: 15px; }
 
 @media (max-width: 880px) {
   .lh-cols { grid-template-columns: 1fr; }
   .lh-loyal { grid-template-columns: repeat(2, 1fr); }
+  .lh-burn { grid-template-columns: 64px minmax(0, 1fr); gap: 9px 12px; }
+  .lh-bend { grid-column: 1 / -1; justify-self: stretch; justify-content: space-between; }
+  .lh-brec { min-width: 0; }
+}
+@media (max-width: 600px) {
+  /* the scatter gets crowded on a phone: shrink the tokens, give the plot more height */
+  .lh-plot { height: 430px; }
+  .lh-qdot { transform: scale(.62); }
+  .lh-qpt.hot .lh-qdot { transform: scale(.7); }
+  .lh-qname { font-size: 9.5px; }
+  .lh-qzone span { font-size: 9px; padding: 5px 7px; }
+  .lh-mv { font-size: 11px; padding: 3px 8px; }
 }
 @media (prefers-reduced-motion: reduce) {
   .lh-banner, .lh-plq { transition: none; transform: none; opacity: 1; }
-  .lh-fill, .lh-barl .b, .lh-barr .b, .lh-led-fill { transition: none; }
+  .lh-fill, .lh-barl .b, .lh-barr .b, .lh-led-fill, .lh-bfill { transition: none; }
   /* keep the static spotlight band + ring; drop only the lift and fades */
   .lh-grow, .lh-cell { transition: none; }
   .lh-grow.is-active, .lh-cell.clk:hover { transform: none; }
+  .lh-mv, .bb-dot, .lh-qdot { transition: none; }
 }

--- a/static/css/league-history.css
+++ b/static/css/league-history.css
@@ -104,10 +104,11 @@
 .lh-cell.clk:hover { transform: translateY(-2px); z-index: 3; box-shadow: 0 0 0 1px #241a06, 0 0 0 2.5px var(--lh-gold-hi), 0 8px 15px -5px rgba(0, 0, 0, .9); }
 .lh-cell.empty { background: repeating-linear-gradient(45deg, transparent 0 3px, rgba(255, 255, 255, .028) 3px 4px); }
 .lh-cell.champ { background: linear-gradient(155deg, var(--lh-gold-hi), var(--lh-gold-deep)); color: #241a06; box-shadow: 0 0 11px -1px var(--lh-glow); position: relative; z-index: 1; }
-.lh-cell.runner { box-shadow: inset 0 0 0 1.5px rgba(179, 188, 198, .6); }
+.lh-cell.runner { background: linear-gradient(155deg, #e4e9ef, #8b94a0); color: #16181c; box-shadow: 0 0 9px -2px rgba(179, 188, 198, .5); position: relative; z-index: 1; }
 .lh-legend { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; margin-top: 16px; font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .04em; font-size: 12px; color: var(--lh-ink3); }
 .lh-lg { display: inline-flex; align-items: center; justify-content: center; width: 14px; height: 14px; border-radius: 3px; vertical-align: -3px; margin-right: 6px; font-size: 9px; color: #241a06; }
 .lh-lg.champ { background: linear-gradient(155deg, var(--lh-gold-hi), var(--lh-gold-deep)); }
+.lh-lg.runner { background: linear-gradient(155deg, #e4e9ef, #8b94a0); color: #16181c; }
 .lh-lg.hi { background: hsl(270 7% 54%); }
 .lh-lg.lo { background: hsl(270 7% 17%); }
 .lh-lg.empty { background: repeating-linear-gradient(45deg, transparent 0 3px, rgba(255, 255, 255, .07) 3px 4px); border: 1px solid var(--lh-line); }

--- a/static/css/league-history.css
+++ b/static/css/league-history.css
@@ -241,11 +241,11 @@
 .lh-bkeep { font-family: "Saira Condensed"; font-weight: 700; font-size: 8.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--lh-ink3); border: 1px solid var(--lh-line2); border-radius: 4px; padding: 1px 5px; }
 .lh-bstat { font-family: "Saira Condensed"; font-weight: 700; font-size: 9px; letter-spacing: .12em; text-transform: uppercase; padding: 1px 6px; border-radius: 4px; }
 .lh-bstat.gone { background: color-mix(in srgb, var(--lh-ember) 18%, var(--deep)); color: var(--lh-ember-hi); }
-.lh-bstat.traded { background: color-mix(in srgb, var(--lh-gold) 16%, var(--deep)); color: var(--lh-gold-hi); }
+.lh-bstat.claimed { background: color-mix(in srgb, var(--lh-gold) 16%, var(--deep)); color: var(--lh-gold-hi); }
 .lh-btrack { height: 12px; background: #14110f; border-radius: 6px; overflow: hidden; }
 .lh-bfill { display: block; height: 100%; width: 0; border-radius: 6px; transition: width 1.1s cubic-bezier(.2, .8, .2, 1); }
 .lh-burn.gone .lh-bfill { background: linear-gradient(90deg, var(--lh-ember-hi), var(--lh-ember) 46%, var(--lh-char) 100%); }
-.lh-burn.traded .lh-bfill { background: linear-gradient(90deg, var(--lh-gold), var(--lh-ember-hi)); }
+.lh-burn.claimed .lh-bfill { background: linear-gradient(90deg, var(--lh-gold), var(--lh-ember-hi)); }
 .lh-bend { display: flex; align-items: center; gap: 14px; justify-self: end; }
 .lh-bprice { font-family: Anton; font-size: 24px; line-height: 1; color: var(--lh-ember-hi); min-width: 52px; text-align: right; }
 .lh-brec { display: flex; align-items: center; gap: 9px; font-family: "Saira Condensed"; font-weight: 700; font-size: 13px; letter-spacing: .03em; color: var(--lh-ink3); min-width: 150px; }
@@ -270,7 +270,7 @@
 .bb-dot { cursor: pointer; transition: r .12s ease; }
 .bb-dot:hover { r: 5.5; }
 .bb-end { font-family: "Saira Condensed"; font-weight: 800; font-size: 13px; letter-spacing: .02em; }
-.lh-boardempty { padding: 80px 20px; text-align: center; color: var(--lh-ink3); font-size: 14px; }
+.bb-hint { fill: var(--lh-ink3); font-family: "Saira Condensed"; font-weight: 600; font-size: 15px; }
 .lh-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
 .lh-chip { display: inline-flex; align-items: center; gap: 7px; font-family: "Saira Condensed"; font-weight: 600; font-size: 12.5px; color: var(--lh-ink2); background: var(--lh-panel2); border: 1px solid var(--lh-line); border-radius: 8px; padding: 5px 10px; cursor: pointer; transition: border-color .14s, color .14s, background .14s; }
 .lh-chip i { font-style: normal; font-family: Anton; font-size: 12px; color: var(--lh-ink3); }

--- a/static/css/league-history.css
+++ b/static/css/league-history.css
@@ -56,7 +56,9 @@
 .lh-banner { position: relative; width: 104px; transform-origin: top center; display: flex; flex-direction: column; align-items: center; transform: translateY(-128%); opacity: 0; transition: transform 1.25s cubic-bezier(.16, .72, .29, 1), opacity .7s ease; }
 .lh-banner.in { transform: translateY(0); opacity: 1; }
 .lh-cord { width: 2px; background: linear-gradient(var(--lh-line2), transparent); }
-.lh-cloth { width: 100%; border-radius: 3px 3px 0 0; position: relative; overflow: hidden; background: linear-gradient(160deg, var(--lh-panel), var(--lh-panel2)); border: 1px solid var(--lh-line2); border-top: none; box-shadow: inset 0 1px 0 rgba(255, 255, 255, .05), 0 18px 30px -18px rgba(0, 0, 0, .9); padding: 14px 8px 0; }
+.lh-cloth { width: 100%; border-radius: 3px 3px 0 0; position: relative; overflow: hidden; background: linear-gradient(160deg, var(--lh-panel), var(--lh-panel2)); border: 1px solid var(--lh-line2); border-top: none; box-shadow: inset 0 1px 0 rgba(255, 255, 255, .05), 0 18px 30px -18px rgba(0, 0, 0, .9); padding: 14px 8px 0; transition: transform .16s ease, box-shadow .16s ease; }
+.lh-banner { cursor: default; }
+.lh-banner:hover .lh-cloth { transform: scale(1.05); box-shadow: inset 0 1px 0 rgba(255, 255, 255, .08), 0 0 34px -8px var(--lh-glow); }
 .lh-banner.champ .lh-cloth { background: linear-gradient(160deg, #2a2210, #1a1407); border-color: rgba(244, 193, 82, .4); box-shadow: inset 0 1px 0 rgba(251, 217, 122, .25), 0 0 34px -10px var(--lh-glow); }
 .lh-cloth::after { content: ""; position: absolute; left: 0; right: 0; bottom: -13px; height: 14px; background: inherit; clip-path: polygon(0 0, 100% 0, 100% 40%, 50% 100%, 0 40%); }
 .lh-bname { font-family: Anton; text-transform: uppercase; font-size: 18px; letter-spacing: .02em; line-height: .95; color: var(--lh-ink); }
@@ -130,8 +132,9 @@
 
 /* ---------- their guy (loyalty) ---------- */
 .lh-loyal { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
-.lh-plq { background: linear-gradient(170deg, var(--lh-panel), var(--lh-panel2)); border: 1px solid var(--lh-line); border-radius: 12px; padding: 18px 16px 16px; position: relative; overflow: hidden; opacity: 0; transform: translateY(14px); transition: .6s; }
+.lh-plq { background: linear-gradient(170deg, var(--lh-panel), var(--lh-panel2)); border: 1px solid var(--lh-line); border-radius: 12px; padding: 18px 16px 16px; position: relative; overflow: hidden; cursor: default; opacity: 0; transform: translateY(14px); transition: opacity .55s ease, transform .18s ease, box-shadow .18s ease, border-color .18s ease; }
 .lh-plq.in { opacity: 1; transform: none; }
+.lh-plq.in:hover { transform: translateY(-4px) scale(1.02); border-color: rgba(244, 193, 82, .45); box-shadow: 0 0 30px -10px var(--lh-glow); }
 .lh-plq.top { border-color: rgba(244, 193, 82, .45); box-shadow: 0 0 30px -14px var(--lh-glow); }
 .lh-of { font-family: "Saira Condensed"; font-weight: 600; letter-spacing: .2em; text-transform: uppercase; font-size: 11px; color: var(--lh-ink3); }
 .lh-of b { color: var(--lh-ink); }
@@ -191,10 +194,15 @@
 .lh-ttline .ch { color: var(--lh-gold-hi); }
 .lh-ttline .ru { color: var(--lh-silver); }
 .lh-tty { display: inline-block; min-width: 26px; color: var(--lh-ink3); font-family: "Saira Condensed"; font-weight: 700; letter-spacing: .02em; }
-/* rows that reveal a hover tooltip */
-.lh-hov { cursor: default; }
-.lh-burn.lh-hov:hover { background: rgba(255, 255, 255, .025); }
-.lh-roy .lh-row.lh-hov:hover { background: rgba(255, 255, 255, .025); }
+.lh-star { font-size: 11px; }
+.lh-star.ch { color: var(--lh-gold-hi); }
+.lh-star.ru { color: var(--lh-silver); }
+/* interactive rows reveal a tooltip and lift with a slight animated zoom on hover */
+.lh-hov { cursor: default; transition: transform .14s ease, background-color .14s ease, box-shadow .14s ease; }
+.lh-row.lh-hov:hover { background: rgba(255, 255, 255, .03); transform: scale(1.015); position: relative; z-index: 2; }
+.lh-burn.lh-hov:hover { background: rgba(255, 255, 255, .03); transform: scale(1.01); position: relative; z-index: 2; }
+.lh-tr.lh-hov:hover { transform: scale(1.015); }
+.lh-tr.lh-hov:hover .who { color: var(--lh-gold-hi); }
 
 /* ---------- roster drawer ---------- */
 .lh-scrim { position: fixed; inset: 0; background: rgba(6, 5, 9, .66); backdrop-filter: blur(2px); z-index: 1001; opacity: 0; visibility: hidden; transition: opacity .3s, visibility .3s; }
@@ -278,8 +286,8 @@
 .bb-grid { stroke: var(--lh-line); stroke-width: 1; }
 .bb-yl, .bb-xl { font-family: "Saira Condensed"; font-weight: 600; font-size: 12px; fill: var(--lh-ink3); }
 .bb-line { fill: none; stroke-width: 2.4; stroke-linejoin: round; stroke-linecap: round; }
-.bb-dot { cursor: pointer; transition: r .12s ease; }
-.bb-dot:hover { r: 5.5; }
+.bb-dot { cursor: pointer; transition: r .12s ease, stroke-width .12s ease; }
+.bb-dot:hover { r: 7.5; stroke: var(--lh-ink); stroke-width: 2.5; }
 .bb-end { font-family: "Saira Condensed"; font-weight: 800; font-size: 13px; letter-spacing: .02em; }
 .bb-hint { fill: var(--lh-ink3); font-family: "Saira Condensed"; font-weight: 600; font-size: 15px; }
 .lh-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
@@ -344,5 +352,6 @@
   /* keep the static spotlight band + ring; drop only the lift and fades */
   .lh-grow, .lh-cell { transition: none; }
   .lh-grow.is-active, .lh-cell.clk:hover { transform: none; }
-  .lh-mv, .bb-dot, .lh-qdot { transition: none; }
+  .lh-mv, .bb-dot, .lh-qdot, .lh-hov, .lh-cloth { transition: none; }
+  .lh-row.lh-hov:hover, .lh-burn.lh-hov:hover, .lh-tr.lh-hov:hover, .lh-plq.in:hover, .lh-banner:hover .lh-cloth { transform: none; }
 }

--- a/static/js/league-history.js
+++ b/static/js/league-history.js
@@ -159,14 +159,14 @@
        retention  — career auction-dollar retention vs. win rate per owner   */
   function deriveMoney(seasons, auctionSeasons) {
     const winpctOf = (t) => { const g = (t.wins || 0) + (t.losses || 0) + (t.ties || 0); return g ? ((t.wins || 0) + 0.5 * (t.ties || 0)) / g : 0; };
-    const posOf = {}, rosterSet = {}, meta = {}, leagueByYear = {}, ownersByYear = {};
+    const rosterSet = {}, meta = {}, leagueByYear = {}, ownersByYear = {};
     seasons.forEach((s) => {
       const champO = s.champion && s.champion.owner, runO = s.runner_up && s.runner_up.owner, shared = !!s.shared_title;
       const lset = leagueByYear[s.year] = new Set();
       const olist = ownersByYear[s.year] = [];
       s.standings.forEach((t) => {
         const set = new Set();
-        (t.roster || []).forEach((e) => { const nn = normName(e.player_name); set.add(nn); lset.add(nn); if (e.position) posOf[nn] = e.position; });
+        (t.roster || []).forEach((e) => { const nn = normName(e.player_name); set.add(nn); lset.add(nn); });
         rosterSet[`${s.year}|${t.owner}`] = set;
         olist.push(t.owner);
         const isC = t.owner === champO || (shared && t.owner === runO);
@@ -225,7 +225,7 @@
         return { owner, retPct: v.retained / v.spend * 100, winPct: g ? (v.wins + 0.5 * v.ties) / g * 100 : 0, seasons: v.seasons, spend: v.spend, retained: v.retained };
       });
 
-    return { years, burns, parc, parcOwner, posOf, retention };
+    return { years, burns, parc, parcOwner, retention };
   }
 
   /* ---------------- scaffold ---------------- */
@@ -468,7 +468,7 @@
   // one detail line for a manager's season: ’YY · team · record ★   (owner added when the list spans managers)
   function seasonLine(owner, year, withOwner) {
     const r = (DATA.rosters[owner] || {})[year] || {};
-    const mid = withOwner ? `${r.team || "?"} · ${owner}` : (r.team || "?");
+    const mid = withOwner ? `${esc(r.team || "?")} · ${esc(owner)}` : esc(r.team || "?");
     return `<div class="lh-ttline"><span class="lh-tty">’${String(year).slice(2)}</span>${mid} · ${r.rec || "—"}${starFor(r)}</div>`;
   }
   const sortYrs = (ys) => (ys || []).slice().sort((a, b) => a - b);
@@ -476,17 +476,17 @@
   // §05 — every season a player was rostered, across managers
   function royaltyTip(p) {
     const rows = (p.app || []).slice().sort((a, b) => a.year - b.year).map((a) => seasonLine(a.owner, a.year, true)).join("");
-    return `<div class="lh-tth">${p.player}</div><div class="lh-ttteam">${p.seasons} seasons rostered</div>${rows}`;
+    return `<div class="lh-tth">${esc(p.player)}</div><div class="lh-ttteam">${p.seasons} seasons rostered</div>${rows}`;
   }
   // top champion banners — the championship seasons
   function bannerTip(o) {
     const ys = sortYrs(DATA.titleYears[o]);
-    return `<div class="lh-tth">${o}</div><div class="lh-ttteam">${ys.length} ${ys.length === 1 ? "title" : "titles"}</div>` + ys.map((y) => seasonLine(o, y)).join("");
+    return `<div class="lh-tth">${esc(o)}</div><div class="lh-ttteam">${ys.length} ${ys.length === 1 ? "title" : "titles"}</div>` + ys.map((y) => seasonLine(o, y)).join("");
   }
   // §02 — the best-record seasons and the title seasons behind the two bars
   function regimeTip(o) {
     const by = sortYrs(DATA.bestYears[o]), ty = sortYrs(DATA.titleYears[o]);
-    let h = `<div class="lh-tth">${o}</div>`;
+    let h = `<div class="lh-tth">${esc(o)}</div>`;
     if (by.length) h += `<div class="lh-ttteam">Best record · ${by.length}</div>` + by.map((y) => seasonLine(o, y)).join("");
     if (ty.length) h += `<div class="lh-ttteam" style="margin-top:8px">Titles · ${ty.length}</div>` + ty.map((y) => seasonLine(o, y)).join("");
     if (!by.length && !ty.length) h += `<div class="lh-ttline">No best records or titles yet</div>`;
@@ -495,12 +495,12 @@
   // §03 — the seasons a manager rostered their go-to player
   function loyaltyTip(l) {
     const ys = sortYrs(l.years);
-    return `<div class="lh-tth">${l.player}</div><div class="lh-ttteam">${l.owner} · ${ys.length} seasons</div>` + ys.map((y) => seasonLine(l.owner, y)).join("");
+    return `<div class="lh-tth">${esc(l.player)}</div><div class="lh-ttteam">${esc(l.owner)} · ${ys.length} seasons</div>` + ys.map((y) => seasonLine(l.owner, y)).join("");
   }
   // §04 — a manager's full season-by-season record
   function ledgerTip(o) {
     const ys = Object.keys(DATA.rosters[o] || {}).map(Number).sort((a, b) => a - b);
-    return `<div class="lh-tth">${o}</div><div class="lh-ttteam">${ys.length} seasons</div>` + ys.map((y) => seasonLine(o, y)).join("");
+    return `<div class="lh-tth">${esc(o)}</div><div class="lh-ttteam">${ys.length} seasons</div>` + ys.map((y) => seasonLine(o, y)).join("");
   }
 
   /* ================= Part II · The Money ================= */
@@ -553,9 +553,9 @@
       const row = ce("div", "lh-burn lh-hov" + (b.gone ? " gone" : " claimed") + (b.win ? " winrec" : ""));
       row.dataset.i = i;
       row.innerHTML =
-        `<div class="lh-bowner">${b.owner}</div>` +
+        `<div class="lh-bowner">${esc(b.owner)}</div>` +
         `<div class="lh-bmid">` +
-          `<div class="lh-bplayer">${b.player}${b.keeper ? `<span class="lh-bkeep">keeper</span>` : ""}` +
+          `<div class="lh-bplayer">${esc(b.player)}${b.keeper ? `<span class="lh-bkeep">keeper</span>` : ""}` +
             `<span class="lh-bstat ${b.gone ? "gone" : "claimed"}">${b.gone ? "Dropped" : "Claimed"}</span></div>` +
           `<div class="lh-btrack"><span class="lh-bfill"></span></div>` +
         `</div>` +
@@ -573,22 +573,22 @@
 
   // who finished the season with the player, and the manager's result that year
   function burnTip(b) {
-    const team = ((DATA.rosters[b.owner] || {})[b.year] || {}).team || "";
+    const team = esc(((DATA.rosters[b.owner] || {})[b.year] || {}).team || "");
     let end;
     if (b.gone) {
       end = `<div class="lh-ttline">Dropped, never re-rostered</div>`;
     } else {
-      const ct = ((DATA.rosters[b.claimedBy] || {})[b.year] || {}).team || "";
+      const ct = esc(((DATA.rosters[b.claimedBy] || {})[b.year] || {}).team || "");
       end = b.claimedBy
-        ? `<div class="lh-ttline">Finished on <b>${b.claimedBy}</b>'s ${ct}</div>`
+        ? `<div class="lh-ttline">Finished on <b>${esc(b.claimedBy)}</b>'s ${ct}</div>`
         : `<div class="lh-ttline">Claimed off waivers by a rival</div>`;
     }
     const res = b.champ ? '<b class="ch">✦ champion</b>' : (b.runner ? '<b class="ru">runner-up</b>' : (b.win ? "winning record" : "missed the cut"));
-    return `<div class="lh-tth">${b.player}</div>` +
-      `<div class="lh-ttteam">${b.year} · ${b.owner}'s ${team}</div>` +
+    return `<div class="lh-tth">${esc(b.player)}</div>` +
+      `<div class="lh-ttteam">${b.year} · ${esc(b.owner)}'s ${team}</div>` +
       `<div class="lh-ttline">$${b.price} at auction${b.keeper ? " · keeper" : ""}</div>` +
       end +
-      `<div class="lh-ttline">${b.owner} went ${b.rec} · ${res}</div>`;
+      `<div class="lh-ttline">${esc(b.owner)} went ${b.rec} · ${res}</div>`;
   }
 
   /* --- 07 · Player Prices Over Time --------------------------------------- */

--- a/static/js/league-history.js
+++ b/static/js/league-history.js
@@ -17,8 +17,8 @@
   // normalize a player name for joining auction prices ↔ end-of-season rosters
   const normName = (n) => (n || "").toLowerCase().replace(/\b(jr|sr|ii|iii|iv|v)\b\.?/g, "").replace(/[^a-z ]/g, "").replace(/\s+/g, " ").trim();
   const esc = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-  const POSVAR = { QB: "--qb", RB: "--rb", WR: "--wr", TE: "--te", K: "--k", "D/ST": "--dst" };
-  const posVar = (p) => POSVAR[p] || "--lh-silver";
+  // distinct, legible-on-dark palette so every charted line reads as its own color
+  const LINECOLORS = ["#4FC3F7", "#FF8A65", "#AED581", "#BA68C8", "#FFD54F", "#F06292", "#4DD0E1", "#9CCC65", "#7986CB", "#FFB74D", "#E57373", "#4DB6AC", "#DCE775", "#90A4AE", "#F48FB1", "#A1887F"];
 
   let DATA = null, MONEY = null, OWNER_COLOR = () => "var(--lh-silver)", built = false;
   let mvSel = new Set();   // currently-charted players on the price chart
@@ -59,18 +59,18 @@
       c.w += t.wins || 0; c.l += t.losses || 0; c.t += t.ties || 0;
     }));
 
-    const titles = {}, lastTitle = {};
+    const titles = {}, lastTitle = {}, titleYears = {};
     seasons.forEach((s) => {
       const winners = [s.champion.owner];
       if (s.shared_title) winners.push(s.runner_up.owner);
-      winners.forEach((o) => { titles[o] = (titles[o] || 0) + 1; lastTitle[o] = Math.max(lastTitle[o] || 0, s.year); });
+      winners.forEach((o) => { titles[o] = (titles[o] || 0) + 1; lastTitle[o] = Math.max(lastTitle[o] || 0, s.year); (titleYears[o] = titleYears[o] || []).push(s.year); });
     });
     const champions = Object.keys(titles)
       .map((o) => ({ owner: o, titles: titles[o], last: lastTitle[o], active: active.has(o) }))
       .sort((a, b) => b.titles - a.titles || b.last - a.last || a.owner.localeCompare(b.owner));
 
-    const best = {};
-    seasons.forEach((s) => { best[s.best_record.owner] = (best[s.best_record.owner] || 0) + 1; });
+    const best = {}, bestYears = {};
+    seasons.forEach((s) => { const o = s.best_record.owner; best[o] = (best[o] || 0) + 1; (bestYears[o] = bestYears[o] || []).push(s.year); });
     const regime = [...new Set([...Object.keys(titles), ...Object.keys(best)])]
       .map((o) => ({ owner: o, titles: titles[o] || 0, best: best[o] || 0, active: active.has(o) }))
       .sort((a, b) => b.best - a.best || b.titles - a.titles);
@@ -102,7 +102,7 @@
       .sort((a, b) => (b.active - a.active) || b.titles - a.titles || b.seasons - a.seasons || avg(a.owner) - avg(b.owner) || a.owner.localeCompare(b.owner));
 
     // loyalty: the player each manager kept rostering
-    const po = {}, posmap = {};
+    const po = {}, posmap = {}, poYears = {};
     seasons.forEach((s) => s.standings.forEach((t) => {
       const seen = new Set();
       (t.roster || []).forEach((e) => {
@@ -110,13 +110,14 @@
         if (seen.has(p) || skipPlayer(p)) return;
         seen.add(p);
         po[p] = po[p] || {}; po[p][t.owner] = (po[p][t.owner] || 0) + 1; posmap[p] = e.position || "";
+        (poYears[p] = poYears[p] || {}); (poYears[p][t.owner] = poYears[p][t.owner] || []).push(s.year);
       });
     }));
     const pairs = [];
     Object.keys(po).forEach((p) => {
       let bo = null, bc = 0;
       Object.entries(po[p]).forEach(([o, c]) => { if (c > bc) { bc = c; bo = o; } });
-      if (bc >= 5) pairs.push({ player: p, owner: bo, seasons: bc, pos: posmap[p] || "" });
+      if (bc >= 5) pairs.push({ player: p, owner: bo, seasons: bc, pos: posmap[p] || "", years: poYears[p][bo] });
     });
     pairs.sort((a, b) => b.seasons - a.seasons);
     const seenO = new Set(); const loy = [];
@@ -146,6 +147,7 @@
     return {
       meta: { years, nSeasons: seasons.length, nManagers: Object.keys(appear).length, latest, active },
       champions, regime, grid: { years, size, rows: gridRows }, loyalty, ledger, royalty, rosters,
+      titleYears, bestYears,
     };
   }
 
@@ -178,7 +180,7 @@
     });
 
     const years = Object.keys(auctionSeasons).map(Number).sort((a, b) => a - b);
-    const burns = [], parc = {}, ret = {};
+    const burns = [], parc = {}, parcOwner = {}, ret = {};
     years.forEach((y) => {
       const owners = (auctionSeasons[String(y)] || {}).owners || {};
       Object.entries(owners).forEach(([owner, picks]) => {
@@ -189,7 +191,8 @@
         (picks || []).forEach((p) => {
           if (skipPlayer(p.player)) return;       // D/ST: not a "superstar", and names rarely match rosters
           const nn = normName(p.player);
-          (parc[p.player] = parc[p.player] || {})[y] = Math.max(parc[p.player][y] || 0, p.price);
+          const arc = parc[p.player] || (parc[p.player] = {});
+          if (arc[y] == null || p.price > arc[y]) { arc[y] = p.price; (parcOwner[p.player] = parcOwner[p.player] || {})[y] = owner; }
           r.spend += p.price;
           if (set && set.has(nn)) { r.retained += p.price; return; }
           if (!set) return;                                   // no roster to judge against
@@ -222,7 +225,7 @@
         return { owner, retPct: v.retained / v.spend * 100, winPct: g ? (v.wins + 0.5 * v.ties) / g * 100 : 0, seasons: v.seasons, spend: v.spend, retained: v.retained };
       });
 
-    return { years, burns, parc, posOf, retention };
+    return { years, burns, parc, parcOwner, posOf, retention };
   }
 
   /* ---------------- scaffold ---------------- */
@@ -297,6 +300,7 @@
     const raf = $("#lh-rafters"), maxT = DATA.champions[0].titles;
     DATA.champions.forEach((c, i) => {
       const b = ce("div", "lh-banner" + (c.titles > 1 ? " champ" : ""));
+      b.dataset.o = c.owner;
       const drop = 20 + Math.round((c.titles / maxT) * 30);
       b.innerHTML =
         `<div class="lh-cord" style="height:${drop}px"></div>
@@ -310,6 +314,11 @@
       raf.appendChild(b);
       setTimeout(() => b.classList.add("in"), 300 + i * 170);
     });
+    raf.addEventListener("mousemove", (e) => {
+      const bn = e.target.closest(".lh-banner"); if (!bn || !bn.dataset.o) { hideTip(); return; }
+      tipAt(bannerTip(bn.dataset.o), e.clientX, e.clientY);
+    });
+    raf.addEventListener("mouseleave", hideTip);
   }
 
   function renderGrid() {
@@ -364,7 +373,8 @@
     const tale = $("#lh-tale"); tale.innerHTML = "";
     reg.forEach((r, i) => {
       const king = r.owner === kingBest || r.owner === kingCrown;
-      const row = ce("div", "lh-tr" + (king ? " king" : ""));
+      const row = ce("div", "lh-tr lh-hov" + (king ? " king" : ""));
+      row.dataset.o = r.owner;
       row.innerHTML =
         `<div class="lh-barl"><span class="bv">${r.best || ""}</span><span class="b"></span></div>` +
         `<div class="who">${r.owner}</div>` +
@@ -375,12 +385,18 @@
         $(".lh-barr .b", row).style.width = (r.titles / maxC * 46) + "%";
       }, 200 + i * 70);
     });
+    tale.addEventListener("mousemove", (e) => {
+      const row = e.target.closest(".lh-tr"); if (!row || !row.dataset.o) { hideTip(); return; }
+      tipAt(regimeTip(row.dataset.o), e.clientX, e.clientY);
+    });
+    tale.addEventListener("mouseleave", hideTip);
   }
 
   function renderLoyalty() {
     const loyal = $("#lh-loyal"); loyal.innerHTML = "";
     DATA.loyalty.forEach((l, i) => {
       const p = ce("div", "lh-plq" + (l.seasons >= 9 ? " top" : ""));
+      p.dataset.i = i;
       p.innerHTML =
         `<span class="lh-pos ${posClass(l.pos)}">${l.pos || "—"}</span>` +
         `<div class="lh-of">${l.owner}<b>'s</b> guy</div>` +
@@ -397,12 +413,18 @@
       }), { threshold: 0.4 });
       setTimeout(() => obs.observe(p), i * 40);
     });
+    loyal.addEventListener("mousemove", (e) => {
+      const card = e.target.closest(".lh-plq"); if (!card || card.dataset.i == null) { hideTip(); return; }
+      tipAt(loyaltyTip(DATA.loyalty[+card.dataset.i]), e.clientX, e.clientY);
+    });
+    loyal.addEventListener("mouseleave", hideTip);
   }
 
   function renderLedger() {
     const el = $("#lh-ledger"); el.innerHTML = "";
     DATA.ledger.forEach((m, i) => {
-      const row = ce("div", "lh-row lh-led" + (m.active ? "" : " gone") + (i === 0 ? " top" : ""));
+      const row = ce("div", "lh-row lh-led lh-hov" + (m.active ? "" : " gone") + (i === 0 ? " top" : ""));
+      row.dataset.o = m.owner;
       const rec = `${m.w}–${m.l}` + (m.t ? `–${m.t}` : "");
       const pct = m.pct.toFixed(3).replace(/^0/, ""); // ".597"
       row.innerHTML =
@@ -412,6 +434,11 @@
       el.appendChild(row);
       setTimeout(() => { $(".lh-led-fill", row).style.width = (m.pct * 100) + "%"; }, 250 + i * 55);
     });
+    el.addEventListener("mousemove", (e) => {
+      const row = e.target.closest(".lh-row"); if (!row || !row.dataset.o) { hideTip(); return; }
+      tipAt(ledgerTip(row.dataset.o), e.clientX, e.clientY);
+    });
+    el.addEventListener("mouseleave", hideTip);
   }
 
   function renderRoyalty() {
@@ -434,14 +461,44 @@
     ro.addEventListener("mouseleave", hideTip);
   }
 
-  // every season a player was rostered: year · team · owner · result
+  // a gold star for a championship season, a silver star for a runner-up
+  const starFor = (r) => r.champ ? ' <span class="lh-star ch">★</span>' : (r.runner ? ' <span class="lh-star ru">★</span>' : "");
+  // one detail line for a manager's season: ’YY · team · record ★   (owner added when the list spans managers)
+  function seasonLine(owner, year, withOwner) {
+    const r = (DATA.rosters[owner] || {})[year] || {};
+    const mid = withOwner ? `${r.team || "?"} · ${owner}` : (r.team || "?");
+    return `<div class="lh-ttline"><span class="lh-tty">’${String(year).slice(2)}</span>${mid} · ${r.rec || "—"}${starFor(r)}</div>`;
+  }
+  const sortYrs = (ys) => (ys || []).slice().sort((a, b) => a - b);
+
+  // §05 — every season a player was rostered, across managers
   function royaltyTip(p) {
-    const rows = (p.app || []).slice().sort((a, b) => a.year - b.year).map((a) => {
-      const r = (DATA.rosters[a.owner] || {})[a.year] || {};
-      const res = r.champ ? '<b class="ch">✦</b>' : (r.runner ? '<b class="ru">RU</b>' : (r.rec || ""));
-      return `<div class="lh-ttline"><span class="lh-tty">’${String(a.year).slice(2)}</span>${r.team || "?"} · ${a.owner} · ${res}</div>`;
-    }).join("");
+    const rows = (p.app || []).slice().sort((a, b) => a.year - b.year).map((a) => seasonLine(a.owner, a.year, true)).join("");
     return `<div class="lh-tth">${p.player}</div><div class="lh-ttteam">${p.seasons} seasons rostered</div>${rows}`;
+  }
+  // top champion banners — the championship seasons
+  function bannerTip(o) {
+    const ys = sortYrs(DATA.titleYears[o]);
+    return `<div class="lh-tth">${o}</div><div class="lh-ttteam">${ys.length} ${ys.length === 1 ? "title" : "titles"}</div>` + ys.map((y) => seasonLine(o, y)).join("");
+  }
+  // §02 — the best-record seasons and the title seasons behind the two bars
+  function regimeTip(o) {
+    const by = sortYrs(DATA.bestYears[o]), ty = sortYrs(DATA.titleYears[o]);
+    let h = `<div class="lh-tth">${o}</div>`;
+    if (by.length) h += `<div class="lh-ttteam">Best record · ${by.length}</div>` + by.map((y) => seasonLine(o, y)).join("");
+    if (ty.length) h += `<div class="lh-ttteam" style="margin-top:8px">Titles · ${ty.length}</div>` + ty.map((y) => seasonLine(o, y)).join("");
+    if (!by.length && !ty.length) h += `<div class="lh-ttline">No best records or titles yet</div>`;
+    return h;
+  }
+  // §03 — the seasons a manager rostered their go-to player
+  function loyaltyTip(l) {
+    const ys = sortYrs(l.years);
+    return `<div class="lh-tth">${l.player}</div><div class="lh-ttteam">${l.owner} · ${ys.length} seasons</div>` + ys.map((y) => seasonLine(l.owner, y)).join("");
+  }
+  // §04 — a manager's full season-by-season record
+  function ledgerTip(o) {
+    const ys = Object.keys(DATA.rosters[o] || {}).map(Number).sort((a, b) => a - b);
+    return `<div class="lh-tth">${o}</div><div class="lh-ttteam">${ys.length} seasons</div>` + ys.map((y) => seasonLine(o, y)).join("");
   }
 
   /* ================= Part II · The Money ================= */
@@ -464,7 +521,7 @@
 
        <section class="lh-sec">
          <div class="lh-sec-head"><span class="lh-num">07</span><h2>Player Prices Over Time</h2></div>
-         <p class="lh-sub">What each player cost at auction, season by season. <b>Lines are colored by position.</b> Four names are charted to start; tap any chip below to add or remove a line.</p>
+         <p class="lh-sub">What each player cost at auction, season by season. Four names are charted to start; tap any chip below to add or remove a line. <b>Hover a point</b> for the price, year, and team that paid it.</p>
          <div class="lh-boardcard">
            <div class="lh-movers" id="lh-movers"></div>
            <div class="lh-board" id="lh-board"></div>
@@ -533,7 +590,7 @@
   }
 
   /* --- 07 · Player Prices Over Time --------------------------------------- */
-  let bbChips = [];
+  let bbChips = [], bbCandIdx = {};
   function renderBigBoard() {
     const years = MONEY.years, y0 = years[0], yN = years[years.length - 1];
     const cand = Object.keys(MONEY.parc).map((pl) => {
@@ -542,6 +599,7 @@
       return { player: pl, peak, n: ys.length, first, last, drama: (peak - first) + (peak - last), full: d[y0] != null && d[yN] != null };
     }).filter((c) => c.n >= 5);
     cand.sort((a, b) => b.peak - a.peak);
+    bbCandIdx = {}; cand.forEach((c, i) => { bbCandIdx[c.player] = i; });   // stable order for color assignment
     bbChips = cand.slice(0, 16);
     bbMaxY = Math.ceil(Math.max(10, ...cand.map((c) => c.peak)) / 10) * 10;   // stable axis across all selections
     const full = cand.filter((c) => c.full);
@@ -562,7 +620,7 @@
       risers.map((c) => mv(c, "up")).join("") + fallers.map((c) => mv(c, "down")).join("");
 
     $("#lh-chips").innerHTML = bbChips.map((c) =>
-      `<button class="lh-chip" data-p="${esc(c.player)}"><span class="lh-chipdot" style="background:var(${posVar(MONEY.posOf[normName(c.player)] || "")})"></span>${c.player}<i>$${c.peak}</i></button>`).join("");
+      `<button class="lh-chip" data-p="${esc(c.player)}"><span class="lh-chipdot"></span>${c.player}<i>$${c.peak}</i></button>`).join("");
 
     const toggle = (pl) => { if (mvSel.has(pl)) mvSel.delete(pl); else mvSel.add(pl); drawBoard(); };
     $("#lh-chips").querySelectorAll(".lh-chip").forEach((b) => { b.onclick = () => toggle(b.dataset.p); });
@@ -572,7 +630,11 @@
     board.addEventListener("mousemove", (e) => {
       const dot = e.target.closest(".bb-dot");
       if (!dot) { hideTip(); return; }
-      tipAt(`<div class="lh-tth">${dot.dataset.p}</div><div class="lh-ttrow">’${String(dot.dataset.y).slice(2)} auction · <b style="color:var(--lh-gold-hi)">$${dot.dataset.v}</b></div>`, e.clientX, e.clientY);
+      const o = dot.dataset.o, y = dot.dataset.y;
+      const team = ((DATA.rosters[o] || {})[y] || {}).team || "";
+      tipAt(`<div class="lh-tth">${dot.dataset.p}</div>` +
+        `<div class="lh-ttteam">${o}${team ? ` · ${team}` : ""}</div>` +
+        `<div class="lh-ttline">’${String(y).slice(2)} auction · <b style="color:var(--lh-gold-hi)">$${dot.dataset.v}</b></div>`, e.clientX, e.clientY);
     });
     board.addEventListener("mouseleave", hideTip);
     drawBoard();
@@ -595,21 +657,30 @@
     }
     years.forEach((y) => { grid += `<text class="bb-xl" x="${xFor(y).toFixed(1)}" y="${H - 12}" text-anchor="middle">’${String(y).slice(2)}</text>`; });
 
+    // assign a distinct color to each charted line (stable order so colors don't churn on toggle)
+    const order = sel.slice().sort((a, b) => (bbCandIdx[a] ?? 999) - (bbCandIdx[b] ?? 999));
+    const colorOf = {}; order.forEach((pl, i) => { colorOf[pl] = LINECOLORS[i % LINECOLORS.length]; });
+
     let lines = "";
-    sel.forEach((pl) => {
+    order.forEach((pl) => {
       const d = MONEY.parc[pl] || {}, pts = years.filter((y) => d[y] != null);
       if (!pts.length) return;
-      const cv = posVar(MONEY.posOf[normName(pl)] || "");
+      const col = colorOf[pl], own = (MONEY.parcOwner[pl] || {});
       const path = pts.map((y, i) => `${i ? "L" : "M"}${xFor(y).toFixed(1)} ${yFor(d[y]).toFixed(1)}`).join(" ");
-      lines += `<path class="bb-line" style="stroke:var(${cv})" d="${path}"/>`;
-      pts.forEach((y) => { lines += `<circle class="bb-dot" style="fill:var(${cv})" cx="${xFor(y).toFixed(1)}" cy="${yFor(d[y]).toFixed(1)}" r="3.6" data-p="${esc(pl)}" data-y="${y}" data-v="${d[y]}"/>`; });
+      lines += `<path class="bb-line" style="stroke:${col}" d="${path}"/>`;
+      pts.forEach((y) => { lines += `<circle class="bb-dot" style="fill:${col}" cx="${xFor(y).toFixed(1)}" cy="${yFor(d[y]).toFixed(1)}" r="4.2" data-p="${esc(pl)}" data-y="${y}" data-v="${d[y]}" data-o="${esc(own[y] || "")}"/>`; });
       const ly = pts[pts.length - 1];
-      lines += `<text class="bb-end" style="fill:var(${cv})" x="${(xFor(ly) + 8).toFixed(1)}" y="${(yFor(d[ly]) + 3.5).toFixed(1)}">${esc(pl.split(" ").slice(-1)[0])}</text>`;
+      lines += `<text class="bb-end" style="fill:${col}" x="${(xFor(ly) + 8).toFixed(1)}" y="${(yFor(d[ly]) + 3.5).toFixed(1)}">${esc(pl.split(" ").slice(-1)[0])}</text>`;
     });
 
     const hint = sel.length ? "" : `<text class="bb-hint" x="${(padL + plotW / 2).toFixed(1)}" y="${(padT + plotH / 2).toFixed(1)}" text-anchor="middle">Tap a player below to chart their auction price</text>`;
     $("#lh-board").innerHTML = `<svg class="bb-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Auction price by year">${grid}${lines}${hint}</svg>`;
-    $("#lh-chips").querySelectorAll(".lh-chip").forEach((c) => c.classList.toggle("on", mvSel.has(c.dataset.p)));
+    $("#lh-chips").querySelectorAll(".lh-chip").forEach((c) => {
+      const on = mvSel.has(c.dataset.p);
+      c.classList.toggle("on", on);
+      const dot = c.querySelector(".lh-chipdot");
+      if (dot) dot.style.background = on ? colorOf[c.dataset.p] : "var(--lh-ink3)";
+    });
   }
 
   /* --- 08 · Auction Retention vs. Win Rate -------------------------------- */

--- a/static/js/league-history.js
+++ b/static/js/league-history.js
@@ -335,13 +335,15 @@
         const c = row.cells[y], edge = y === 2012 ? " edge" : "";
         if (!c) return `<div class="lh-cell empty${edge}"></div>`;
         if (c.champ) return `<div class="lh-cell champ clk${edge}" data-o="${row.owner}" data-y="${y}">★</div>`;
-        return `<div class="lh-cell clk${c.runner ? " runner" : ""}${edge}" data-o="${row.owner}" data-y="${y}" style="background:${heat(c.r, G.size[y])}"></div>`;
+        if (c.runner) return `<div class="lh-cell runner clk${edge}" data-o="${row.owner}" data-y="${y}">★</div>`;
+        return `<div class="lh-cell clk${edge}" data-o="${row.owner}" data-y="${y}" style="background:${heat(c.r, G.size[y])}"></div>`;
       }).join("");
       html += `<div class="lh-grow">${name}${cellsH}</div>`;
     });
     gridEl.innerHTML = html;
     $("#lh-legend").innerHTML =
       `<span><i class="lh-lg champ">★</i>won the title</span>` +
+      `<span><i class="lh-lg runner">★</i>runner-up</span>` +
       `<span><i class="lh-lg hi"></i>strong season</span>` +
       `<span><i class="lh-lg lo"></i>down year</span>` +
       `<span><i class="lh-lg empty"></i>not in the league</span>` +

--- a/static/js/league-history.js
+++ b/static/js/league-history.js
@@ -21,7 +21,8 @@
   const posVar = (p) => POSVAR[p] || "--lh-silver";
 
   let DATA = null, MONEY = null, OWNER_COLOR = () => "var(--lh-silver)", built = false;
-  let mvSel = new Set();   // currently-charted players on The Big Board
+  let mvSel = new Set();   // currently-charted players on the price chart
+  let bbMaxY = 80;         // fixed y-axis ceiling so toggling lines never rescales the chart
 
   /* shared hover tooltip (reuses #lhTip) for the money charts */
   function tipAt(html, x, y) {
@@ -188,8 +189,11 @@
           if (!set) return;                                   // no roster to judge against
           const inLeague = (leagueByYear[y] || new Set()).has(nn);
           burns.push({
+            // a "burn" = an auction buy missing from the owner's end-of-season roster.
+            // gone   = not on ANY roster at year's end (dropped, never re-rostered)
+            // claimed = on a RIVAL's end-of-season roster (dropped, then picked up off waivers)
             year: y, owner, player: p.player, price: p.price, keeper: !!p.keeper,
-            gone: !inLeague, traded: inLeague,
+            gone: !inLeague, claimed: inLeague,
             rec: m ? m.rec : "", win: m ? m.wins > m.losses : false,
             champ: m ? m.champ : false, runner: m ? m.runner : false,
           });
@@ -230,27 +234,27 @@
         </section>
 
         <section class="lh-sec">
-          <div class="lh-sec-head"><span class="lh-num">02</span><h2>Régime vs. Crown</h2></div>
-          <p class="lh-sub">Best regular-season record is a régime; a championship is a crown. They don't always go to the same house — the gap between the two columns is the gap between dominant and decisive.</p>
-          <div class="lh-talehead"><div class="l">Best records · régime</div><div class="c">Manager</div><div class="r">Titles · crown</div></div>
+          <div class="lh-sec-head"><span class="lh-num">02</span><h2>Best Records vs. Titles</h2></div>
+          <p class="lh-sub">Most seasons with the best regular-season record, against most championships won. They don't always go to the same manager — the gap between the two columns is the gap between dominant and decisive.</p>
+          <div class="lh-talehead"><div class="l">Best records</div><div class="c">Manager</div><div class="r">Titles</div></div>
           <div class="lh-tale" id="lh-tale"></div>
         </section>
 
         <section class="lh-sec">
-          <div class="lh-sec-head"><span class="lh-num">03</span><h2>Their Guy</h2></div>
-          <p class="lh-sub">Some attachments outlast coaching staffs. These are the players each manager kept coming back for — drafted or stashed, season after season.</p>
+          <div class="lh-sec-head"><span class="lh-num">03</span><h2>Most-Rostered Player, by Manager</h2></div>
+          <p class="lh-sub">The player each manager kept coming back for — drafted or stashed, season after season — and how many seasons they rostered them.</p>
           <div class="lh-loyal" id="lh-loyal"></div>
         </section>
 
         <div class="lh-cols">
           <section class="lh-sec" style="margin-top:0">
-            <div class="lh-sec-head"><span class="lh-num">04</span><h2>The Ledger</h2></div>
+            <div class="lh-sec-head"><span class="lh-num">04</span><h2>Career Win-Loss Records</h2></div>
             <p class="lh-sub">Every manager's career regular-season record — <b>gold is wins, the rest is losses</b>, best rate on top. Three seasons or more.</p>
             <div id="lh-ledger"></div>
             <p class="lh-foot">Regular-season games only — playoffs aren't counted. <b>Ties score as half a win.</b></p>
           </section>
           <section class="lh-sec lh-roy" style="margin-top:0">
-            <div class="lh-sec-head"><span class="lh-num">05</span><h2>League Royalty</h2></div>
+            <div class="lh-sec-head"><span class="lh-num">05</span><h2>Most-Rostered Players, League-Wide</h2></div>
             <p class="lh-sub">The NFL names that defined the era — most seasons rostered by <i>anyone</i> in the league.</p>
             <div id="lh-royalty"></div>
           </section>
@@ -417,21 +421,21 @@
     return (
       `<div class="lh-act">
          <span class="lh-actrule"></span>
-         <span class="lh-acttext">Part II &middot; The Money</span>
+         <span class="lh-acttext">Auction Money &middot; ${span}</span>
          <span class="lh-actrule"></span>
        </div>
-       <p class="lh-actsub">Auction salaries, ${span} &mdash; what the room paid, what survived the season, and who turned it into wins.</p>
+       <p class="lh-actsub">What each player cost at auction, what stayed on the roster, and how it lined up with winning.</p>
 
        <section class="lh-sec">
-         <div class="lh-sec-head"><span class="lh-num">06</span><h2>Sunk Costs</h2></div>
-         <p class="lh-sub">Big money at the block, gone by the final whistle &mdash; auction buys that weren't on the roster at season's end. <b>Charred bars left the league entirely; amber ones were traded away.</b> The glowing tags are the managers who <b>won anyway.</b></p>
+         <div class="lh-sec-head"><span class="lh-num">06</span><h2>Priciest Dropped Players</h2></div>
+         <p class="lh-sub">The most expensive players who weren't on their manager's roster at season's end. <b>Charred bars were dropped and never re-rostered; amber bars were dropped, then claimed by a rival off waivers.</b> Glowing tags mark managers who <b>won anyway.</b></p>
          <div class="lh-sunkcard"><div id="lh-sunk"></div></div>
-         <p class="lh-foot">Keepers count as committed dollars. A burn is any auction buy missing from that manager's end-of-season roster.</p>
+         <p class="lh-foot">Keepers count as committed dollars. This counts any auction buy missing from the manager's end-of-season roster.</p>
        </section>
 
        <section class="lh-sec">
-         <div class="lh-sec-head"><span class="lh-num">07</span><h2>The Big Board</h2></div>
-         <p class="lh-sub">Nine auctions, one ticker. What the room was willing to pay for the names that moved the market &mdash; <b>lines are colored by position.</b> Tap a player to chart or drop their price line.</p>
+         <div class="lh-sec-head"><span class="lh-num">07</span><h2>Player Prices Over Time</h2></div>
+         <p class="lh-sub">What each player cost at auction, season by season &mdash; <b>lines are colored by position.</b> Four names are charted to start; tap any chip below to add or remove a line.</p>
          <div class="lh-boardcard">
            <div class="lh-movers" id="lh-movers"></div>
            <div class="lh-board" id="lh-board"></div>
@@ -440,14 +444,15 @@
        </section>
 
        <section class="lh-sec">
-         <div class="lh-sec-head"><span class="lh-num">08</span><h2>Maestro &amp; Wizard</h2></div>
-         <p class="lh-sub">Two ways to win: <b>master the auction</b> (keep the players you paid for) or <b>master the waiver wire</b> (win with the ones you didn't). Career auction-dollar retention against regular-season win rate. <b>Bigger tokens mean more seasons played.</b></p>
+         <div class="lh-sec-head"><span class="lh-num">08</span><h2>Auction Retention vs. Win Rate</h2></div>
+         <p class="lh-sub">Two ways to win: keep the players you paid for at auction, or win with players added off waivers. Each manager's share of auction dollars still on the roster at season's end, plotted against win rate over the auction years. <b>Bigger tokens mean more seasons played.</b></p>
          <div class="lh-quad" id="lh-quad"></div>
+         <p class="lh-foot">Win rate here covers the auction years (${span}) only, so it won't match the all-time Ledger above.</p>
        </section>`
     );
   }
 
-  /* --- 06 · Sunk Costs ----------------------------------------------------- */
+  /* --- 06 · Priciest Dropped Players -------------------------------------- */
   function renderSunkCosts() {
     const el = $("#lh-sunk"); if (!el) return;
     el.innerHTML = "";
@@ -457,12 +462,12 @@
       const tag = b.champ ? `<span class="lh-btag champ">★ Champion</span>`
         : b.runner ? `<span class="lh-btag won">Runner-up</span>`
           : b.win ? `<span class="lh-btag won">Won anyway</span>` : "";
-      const row = ce("div", "lh-burn" + (b.gone ? " gone" : " traded") + (b.win ? " winrec" : ""));
+      const row = ce("div", "lh-burn" + (b.gone ? " gone" : " claimed") + (b.win ? " winrec" : ""));
       row.innerHTML =
         `<div class="lh-bowner">${b.owner}</div>` +
         `<div class="lh-bmid">` +
           `<div class="lh-bplayer">${b.player}${b.keeper ? `<span class="lh-bkeep">keeper</span>` : ""}` +
-            `<span class="lh-bstat ${b.gone ? "gone" : "traded"}">${b.gone ? "Gone" : "Traded"}</span></div>` +
+            `<span class="lh-bstat ${b.gone ? "gone" : "claimed"}">${b.gone ? "Dropped" : "Claimed"}</span></div>` +
           `<div class="lh-btrack"><span class="lh-bfill"></span></div>` +
         `</div>` +
         `<div class="lh-bend"><div class="lh-bprice">$${b.price}</div>` +
@@ -472,7 +477,7 @@
     });
   }
 
-  /* --- 07 · The Big Board -------------------------------------------------- */
+  /* --- 07 · Player Prices Over Time --------------------------------------- */
   let bbChips = [];
   function renderBigBoard() {
     const years = MONEY.years, y0 = years[0], yN = years[years.length - 1];
@@ -483,6 +488,7 @@
     }).filter((c) => c.n >= 5);
     cand.sort((a, b) => b.peak - a.peak);
     bbChips = cand.slice(0, 16);
+    bbMaxY = Math.ceil(Math.max(10, ...cand.map((c) => c.peak)) / 10) * 10;   // stable axis across all selections
     const full = cand.filter((c) => c.full);
     // default to the most dramatic arcs that also have a toggle chip on screen,
     // preferring full-decade players, then topping up to four by sheer drama
@@ -521,17 +527,18 @@
     const sel = [...mvSel], years = MONEY.years, y0 = years[0], yN = years[years.length - 1];
     const W = 920, H = 360, padL = 52, padR = 78, padT = 16, padB = 34, plotW = W - padL - padR, plotH = H - padT - padB;
     const xFor = (y) => padL + (yN === y0 ? 0 : (y - y0) / (yN - y0)) * plotW;
-    let maxY = Math.max(10, ...sel.flatMap((pl) => Object.values(MONEY.parc[pl] || {})));
-    maxY = Math.ceil(maxY / 10) * 10;
+    const maxY = bbMaxY;                              // fixed: toggling lines never rescales the chart
     const yFor = (v) => padT + (1 - v / maxY) * plotH;
+    const step = maxY > 60 ? 20 : 10;
 
+    // axes + gridlines are always drawn, so the chart keeps a stable footprint even with nothing selected
     let grid = "";
-    for (let v = 0; v <= maxY; v += 10) {
+    for (let v = 0; v <= maxY; v += step) {
       const yy = yFor(v);
-      grid += `<line class="bb-grid" x1="${padL}" y1="${yy}" x2="${W - padR}" y2="${yy}"/>` +
-        `<text class="bb-yl" x="${padL - 8}" y="${yy + 3.5}" text-anchor="end">$${v}</text>`;
+      grid += `<line class="bb-grid" x1="${padL}" y1="${yy.toFixed(1)}" x2="${W - padR}" y2="${yy.toFixed(1)}"/>` +
+        `<text class="bb-yl" x="${padL - 8}" y="${(yy + 3.5).toFixed(1)}" text-anchor="end">$${v}</text>`;
     }
-    years.forEach((y) => { grid += `<text class="bb-xl" x="${xFor(y)}" y="${H - 12}" text-anchor="middle">’${String(y).slice(2)}</text>`; });
+    years.forEach((y) => { grid += `<text class="bb-xl" x="${xFor(y).toFixed(1)}" y="${H - 12}" text-anchor="middle">’${String(y).slice(2)}</text>`; });
 
     let lines = "";
     sel.forEach((pl) => {
@@ -545,13 +552,12 @@
       lines += `<text class="bb-end" style="fill:var(${cv})" x="${(xFor(ly) + 8).toFixed(1)}" y="${(yFor(d[ly]) + 3.5).toFixed(1)}">${esc(pl.split(" ").slice(-1)[0])}</text>`;
     });
 
-    $("#lh-board").innerHTML = sel.length
-      ? `<svg class="bb-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Auction price by year">${grid}${lines}</svg>`
-      : `<div class="lh-boardempty">Tap a player below to chart their auction price.</div>`;
+    const hint = sel.length ? "" : `<text class="bb-hint" x="${(padL + plotW / 2).toFixed(1)}" y="${(padT + plotH / 2).toFixed(1)}" text-anchor="middle">Tap a player below to chart their auction price</text>`;
+    $("#lh-board").innerHTML = `<svg class="bb-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Auction price by year">${grid}${lines}${hint}</svg>`;
     $("#lh-chips").querySelectorAll(".lh-chip").forEach((c) => c.classList.toggle("on", mvSel.has(c.dataset.p)));
   }
 
-  /* --- 08 · Maestro & Wizard ---------------------------------------------- */
+  /* --- 08 · Auction Retention vs. Win Rate -------------------------------- */
   function renderManagerMap() {
     const el = $("#lh-quad"); if (!el) return;
     const pts = MONEY.retention.slice();
@@ -565,10 +571,10 @@
     const mxp = X(medX), myp = Y(medY), maxS = Math.max(...pts.map((p) => p.seasons));
 
     let inner =
-      `<div class="lh-qzone maestro" style="left:${mxp}%;top:0;width:${100 - mxp}%;height:${myp}%"><span>The Maestro</span></div>` +
-      `<div class="lh-qzone wizard" style="left:0;top:0;width:${mxp}%;height:${myp}%"><span>The Wizard</span></div>` +
-      `<div class="lh-qzone forget" style="left:${mxp}%;top:${myp}%;width:${100 - mxp}%;height:${100 - myp}%"><span>Set &amp; Forget</span></div>` +
-      `<div class="lh-qzone adrift" style="left:0;top:${myp}%;width:${mxp}%;height:${100 - myp}%"><span>Adrift</span></div>` +
+      `<div class="lh-qzone maestro" style="left:${mxp}%;top:0;width:${100 - mxp}%;height:${myp}%"><span>Won via auction</span></div>` +
+      `<div class="lh-qzone wizard" style="left:0;top:0;width:${mxp}%;height:${myp}%"><span>Won via waivers</span></div>` +
+      `<div class="lh-qzone forget" style="left:${mxp}%;top:${myp}%;width:${100 - mxp}%;height:${100 - myp}%"><span>Kept players, lost</span></div>` +
+      `<div class="lh-qzone adrift" style="left:0;top:${myp}%;width:${mxp}%;height:${100 - myp}%"><span>Lost both ways</span></div>` +
       `<div class="lh-qx" style="left:${mxp}%"><span>med ${Math.round(medX)}%</span></div>` +
       `<div class="lh-qy" style="top:${myp}%"><span>med ${Math.round(medY)}%</span></div>`;
     pts.forEach((p) => {

--- a/static/js/league-history.js
+++ b/static/js/league-history.js
@@ -7,13 +7,43 @@
 (function () {
   "use strict";
   const API = "/api/v1/league-history";
+  const AUCTION_API = "/api/v1/auction-prices";
+  const OWNERS_API = "/api/v1/owners";
   const $ = (s, el) => (el || document).querySelector(s);
   const ce = (t, c) => { const e = document.createElement(t); if (c) e.className = c; return e; };
   const ord = (n) => n + (n % 100 >= 11 && n % 100 <= 13 ? "th" : ({ 1: "st", 2: "nd", 3: "rd" }[n % 10] || "th"));
   const posClass = (p) => (p || "").replace("/", "") || "NA";
   const skipPlayer = (n) => /D\/ST| - DEF/.test(n);
+  // normalize a player name for joining auction prices ↔ end-of-season rosters
+  const normName = (n) => (n || "").toLowerCase().replace(/\b(jr|sr|ii|iii|iv|v)\b\.?/g, "").replace(/[^a-z ]/g, "").replace(/\s+/g, " ").trim();
+  const esc = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  const POSVAR = { QB: "--qb", RB: "--rb", WR: "--wr", TE: "--te", K: "--k", "D/ST": "--dst" };
+  const posVar = (p) => POSVAR[p] || "--lh-silver";
 
-  let DATA = null, built = false;
+  let DATA = null, MONEY = null, OWNER_COLOR = () => "var(--lh-silver)", built = false;
+  let mvSel = new Set();   // currently-charted players on The Big Board
+
+  /* shared hover tooltip (reuses #lhTip) for the money charts */
+  function tipAt(html, x, y) {
+    const tip = $("#lhTip"); tip.innerHTML = html; tip.classList.add("on");
+    const pad = 14, w = tip.offsetWidth, h = tip.offsetHeight;
+    let L = x + pad, T = y + pad;
+    if (L + w > innerWidth - 8) L = x - pad - w;
+    if (T + h > innerHeight - 8) T = y - pad - h;
+    tip.style.left = L + "px"; tip.style.top = T + "px";
+  }
+  const hideTip = () => $("#lhTip").classList.remove("on");
+
+  // owner → brand color (owners.json for the active league, stable hash for departed owners)
+  function buildOwnerColor(owners) {
+    const map = {};
+    (owners || []).forEach((o) => { if (o && o.owner_name && o.color) map[o.owner_name] = o.color; });
+    return (name) => {
+      if (map[name]) return map[name];
+      let h = 0; for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) % 360;
+      return `hsl(${h} 55% 62%)`;
+    };
+  }
 
   /* ---------------- derive everything from raw seasons ---------------- */
   function derive(seasonsIn) {
@@ -114,8 +144,73 @@
     };
   }
 
+  /* ---------------- derive the auction-money views ----------------
+     Joins the auction archive (season → owner → picks) against the
+     end-of-season rosters in league history. Produces:
+       burns      — auction buys NOT on their owner's final roster
+       parc       — every player's price arc across the auction years
+       retention  — career auction-dollar retention vs. win rate per owner   */
+  function deriveMoney(seasons, auctionSeasons) {
+    const winpctOf = (t) => { const g = (t.wins || 0) + (t.losses || 0) + (t.ties || 0); return g ? ((t.wins || 0) + 0.5 * (t.ties || 0)) / g : 0; };
+    const posOf = {}, rosterSet = {}, meta = {}, leagueByYear = {};
+    seasons.forEach((s) => {
+      const champO = s.champion && s.champion.owner, runO = s.runner_up && s.runner_up.owner, shared = !!s.shared_title;
+      const lset = leagueByYear[s.year] = new Set();
+      s.standings.forEach((t) => {
+        const set = new Set();
+        (t.roster || []).forEach((e) => { const nn = normName(e.player_name); set.add(nn); lset.add(nn); if (e.position) posOf[nn] = e.position; });
+        rosterSet[`${s.year}|${t.owner}`] = set;
+        const isC = t.owner === champO || (shared && t.owner === runO);
+        const isR = t.owner === runO && !shared;
+        meta[`${s.year}|${t.owner}`] = {
+          wins: t.wins || 0, losses: t.losses || 0, ties: t.ties || 0, winpct: winpctOf(t),
+          rec: `${t.wins || 0}-${t.losses || 0}` + (t.ties ? `-${t.ties}` : ""),
+          champ: isC, runner: isR, team: t.team_name,
+        };
+      });
+    });
+
+    const years = Object.keys(auctionSeasons).map(Number).sort((a, b) => a - b);
+    const burns = [], parc = {}, ret = {};
+    years.forEach((y) => {
+      const owners = (auctionSeasons[String(y)] || {}).owners || {};
+      Object.entries(owners).forEach(([owner, picks]) => {
+        const set = rosterSet[`${y}|${owner}`], m = meta[`${y}|${owner}`];
+        const r = ret[owner] || (ret[owner] = { spend: 0, retained: 0, wins: 0, losses: 0, ties: 0, seasons: 0 });
+        r.seasons++;
+        if (m) { r.wins += m.wins; r.losses += m.losses; r.ties += m.ties; }
+        (picks || []).forEach((p) => {
+          if (skipPlayer(p.player)) return;       // D/ST: not a "superstar", and names rarely match rosters
+          const nn = normName(p.player);
+          (parc[p.player] = parc[p.player] || {})[y] = Math.max(parc[p.player][y] || 0, p.price);
+          r.spend += p.price;
+          if (set && set.has(nn)) { r.retained += p.price; return; }
+          if (!set) return;                                   // no roster to judge against
+          const inLeague = (leagueByYear[y] || new Set()).has(nn);
+          burns.push({
+            year: y, owner, player: p.player, price: p.price, keeper: !!p.keeper,
+            gone: !inLeague, traded: inLeague,
+            rec: m ? m.rec : "", win: m ? m.wins > m.losses : false,
+            champ: m ? m.champ : false, runner: m ? m.runner : false,
+          });
+        });
+      });
+    });
+    burns.sort((a, b) => b.price - a.price || a.year - b.year);
+
+    const retention = Object.entries(ret)
+      .filter(([, v]) => v.seasons >= 3 && v.spend > 0)
+      .map(([owner, v]) => {
+        const g = v.wins + v.losses + v.ties;
+        return { owner, retPct: v.retained / v.spend * 100, winPct: g ? (v.wins + 0.5 * v.ties) / g * 100 : 0, seasons: v.seasons, spend: v.spend, retained: v.retained };
+      });
+
+    return { years, burns, parc, posOf, retention };
+  }
+
   /* ---------------- scaffold ---------------- */
   function scaffold(host) {
+    const money = MONEY ? moneyScaffold() : "";
     host.innerHTML =
       `<div class="lh-wrap">
         <header class="lh-mast">
@@ -160,6 +255,7 @@
             <div id="lh-royalty"></div>
           </section>
         </div>
+        ${money}
       </div>`;
 
     if (!$("#lhDrawer")) {
@@ -315,6 +411,193 @@
     });
   }
 
+  /* ================= Part II · The Money ================= */
+  function moneyScaffold() {
+    const yrs = MONEY.years, span = yrs.length ? `${yrs[0]}–${yrs[yrs.length - 1]}` : "";
+    return (
+      `<div class="lh-act">
+         <span class="lh-actrule"></span>
+         <span class="lh-acttext">Part II &middot; The Money</span>
+         <span class="lh-actrule"></span>
+       </div>
+       <p class="lh-actsub">Auction salaries, ${span} &mdash; what the room paid, what survived the season, and who turned it into wins.</p>
+
+       <section class="lh-sec">
+         <div class="lh-sec-head"><span class="lh-num">06</span><h2>Sunk Costs</h2></div>
+         <p class="lh-sub">Big money at the block, gone by the final whistle &mdash; auction buys that weren't on the roster at season's end. <b>Charred bars left the league entirely; amber ones were traded away.</b> The glowing tags are the managers who <b>won anyway.</b></p>
+         <div class="lh-sunkcard"><div id="lh-sunk"></div></div>
+         <p class="lh-foot">Keepers count as committed dollars. A burn is any auction buy missing from that manager's end-of-season roster.</p>
+       </section>
+
+       <section class="lh-sec">
+         <div class="lh-sec-head"><span class="lh-num">07</span><h2>The Big Board</h2></div>
+         <p class="lh-sub">Nine auctions, one ticker. What the room was willing to pay for the names that moved the market &mdash; <b>lines are colored by position.</b> Tap a player to chart or drop their price line.</p>
+         <div class="lh-boardcard">
+           <div class="lh-movers" id="lh-movers"></div>
+           <div class="lh-board" id="lh-board"></div>
+           <div class="lh-chips" id="lh-chips"></div>
+         </div>
+       </section>
+
+       <section class="lh-sec">
+         <div class="lh-sec-head"><span class="lh-num">08</span><h2>Maestro &amp; Wizard</h2></div>
+         <p class="lh-sub">Two ways to win: <b>master the auction</b> (keep the players you paid for) or <b>master the waiver wire</b> (win with the ones you didn't). Career auction-dollar retention against regular-season win rate. <b>Bigger tokens mean more seasons played.</b></p>
+         <div class="lh-quad" id="lh-quad"></div>
+       </section>`
+    );
+  }
+
+  /* --- 06 · Sunk Costs ----------------------------------------------------- */
+  function renderSunkCosts() {
+    const el = $("#lh-sunk"); if (!el) return;
+    el.innerHTML = "";
+    const shown = MONEY.burns.slice(0, 14);
+    const maxP = Math.max(1, ...MONEY.burns.map((b) => b.price));
+    shown.forEach((b, i) => {
+      const tag = b.champ ? `<span class="lh-btag champ">★ Champion</span>`
+        : b.runner ? `<span class="lh-btag won">Runner-up</span>`
+          : b.win ? `<span class="lh-btag won">Won anyway</span>` : "";
+      const row = ce("div", "lh-burn" + (b.gone ? " gone" : " traded") + (b.win ? " winrec" : ""));
+      row.innerHTML =
+        `<div class="lh-bowner">${b.owner}</div>` +
+        `<div class="lh-bmid">` +
+          `<div class="lh-bplayer">${b.player}${b.keeper ? `<span class="lh-bkeep">keeper</span>` : ""}` +
+            `<span class="lh-bstat ${b.gone ? "gone" : "traded"}">${b.gone ? "Gone" : "Traded"}</span></div>` +
+          `<div class="lh-btrack"><span class="lh-bfill"></span></div>` +
+        `</div>` +
+        `<div class="lh-bend"><div class="lh-bprice">$${b.price}</div>` +
+          `<div class="lh-brec">${b.rec}${tag}</div></div>`;
+      el.appendChild(row);
+      setTimeout(() => { $(".lh-bfill", row).style.width = (b.price / maxP * 100) + "%"; }, 220 + i * 55);
+    });
+  }
+
+  /* --- 07 · The Big Board -------------------------------------------------- */
+  let bbChips = [];
+  function renderBigBoard() {
+    const years = MONEY.years, y0 = years[0], yN = years[years.length - 1];
+    const cand = Object.keys(MONEY.parc).map((pl) => {
+      const d = MONEY.parc[pl], ys = Object.keys(d).map(Number), vals = ys.map((y) => d[y]);
+      const first = d[Math.min(...ys)], last = d[Math.max(...ys)], peak = Math.max(...vals);
+      return { player: pl, peak, n: ys.length, first, last, drama: (peak - first) + (peak - last), full: d[y0] != null && d[yN] != null };
+    }).filter((c) => c.n >= 5);
+    cand.sort((a, b) => b.peak - a.peak);
+    bbChips = cand.slice(0, 16);
+    const full = cand.filter((c) => c.full);
+    // default to the most dramatic arcs that also have a toggle chip on screen,
+    // preferring full-decade players, then topping up to four by sheer drama
+    const byDrama = bbChips.slice().sort((a, b) => b.drama - a.drama);
+    const defaults = byDrama.filter((c) => c.full).slice(0, 4).map((c) => c.player);
+    for (const c of byDrama) { if (defaults.length >= 4) break; if (!defaults.includes(c.player)) defaults.push(c.player); }
+    mvSel = new Set(defaults);
+
+    // market-movers ticker — biggest run-ups and biggest collapses (each player's own span; no repeats)
+    const risers = cand.slice().sort((a, b) => (b.peak - b.first) - (a.peak - a.first)).slice(0, 2);
+    const riserSet = new Set(risers.map((c) => c.player));
+    const fallers = cand.filter((c) => !riserSet.has(c.player)).sort((a, b) => (b.peak - b.last) - (a.peak - a.last)).slice(0, 2);
+    const mv = (c, dir) => `<button class="lh-mv ${dir}" data-p="${esc(c.player)}">${dir === "up" ? "▲" : "▼"} <b>${c.player.split(" ").slice(-1)[0]}</b> $${dir === "up" ? c.first : c.peak}→$${dir === "up" ? c.peak : c.last}</button>`;
+    $("#lh-movers").innerHTML =
+      `<span class="lh-mvlbl">Movers</span>` +
+      risers.map((c) => mv(c, "up")).join("") + fallers.map((c) => mv(c, "down")).join("");
+
+    $("#lh-chips").innerHTML = bbChips.map((c) =>
+      `<button class="lh-chip" data-p="${esc(c.player)}"><span class="lh-chipdot" style="background:var(${posVar(MONEY.posOf[normName(c.player)] || "")})"></span>${c.player}<i>$${c.peak}</i></button>`).join("");
+
+    const toggle = (pl) => { if (mvSel.has(pl)) mvSel.delete(pl); else mvSel.add(pl); drawBoard(); };
+    $("#lh-chips").querySelectorAll(".lh-chip").forEach((b) => { b.onclick = () => toggle(b.dataset.p); });
+    $("#lh-movers").querySelectorAll(".lh-mv").forEach((b) => { b.onclick = () => toggle(b.dataset.p); });
+
+    const board = $("#lh-board");
+    board.addEventListener("mousemove", (e) => {
+      const dot = e.target.closest(".bb-dot");
+      if (!dot) { hideTip(); return; }
+      tipAt(`<div class="lh-tth">${dot.dataset.p}</div><div class="lh-ttrow">’${String(dot.dataset.y).slice(2)} auction · <b style="color:var(--lh-gold-hi)">$${dot.dataset.v}</b></div>`, e.clientX, e.clientY);
+    });
+    board.addEventListener("mouseleave", hideTip);
+    drawBoard();
+  }
+
+  function drawBoard() {
+    const sel = [...mvSel], years = MONEY.years, y0 = years[0], yN = years[years.length - 1];
+    const W = 920, H = 360, padL = 52, padR = 78, padT = 16, padB = 34, plotW = W - padL - padR, plotH = H - padT - padB;
+    const xFor = (y) => padL + (yN === y0 ? 0 : (y - y0) / (yN - y0)) * plotW;
+    let maxY = Math.max(10, ...sel.flatMap((pl) => Object.values(MONEY.parc[pl] || {})));
+    maxY = Math.ceil(maxY / 10) * 10;
+    const yFor = (v) => padT + (1 - v / maxY) * plotH;
+
+    let grid = "";
+    for (let v = 0; v <= maxY; v += 10) {
+      const yy = yFor(v);
+      grid += `<line class="bb-grid" x1="${padL}" y1="${yy}" x2="${W - padR}" y2="${yy}"/>` +
+        `<text class="bb-yl" x="${padL - 8}" y="${yy + 3.5}" text-anchor="end">$${v}</text>`;
+    }
+    years.forEach((y) => { grid += `<text class="bb-xl" x="${xFor(y)}" y="${H - 12}" text-anchor="middle">’${String(y).slice(2)}</text>`; });
+
+    let lines = "";
+    sel.forEach((pl) => {
+      const d = MONEY.parc[pl] || {}, pts = years.filter((y) => d[y] != null);
+      if (!pts.length) return;
+      const cv = posVar(MONEY.posOf[normName(pl)] || "");
+      const path = pts.map((y, i) => `${i ? "L" : "M"}${xFor(y).toFixed(1)} ${yFor(d[y]).toFixed(1)}`).join(" ");
+      lines += `<path class="bb-line" style="stroke:var(${cv})" d="${path}"/>`;
+      pts.forEach((y) => { lines += `<circle class="bb-dot" style="fill:var(${cv})" cx="${xFor(y).toFixed(1)}" cy="${yFor(d[y]).toFixed(1)}" r="3.6" data-p="${esc(pl)}" data-y="${y}" data-v="${d[y]}"/>`; });
+      const ly = pts[pts.length - 1];
+      lines += `<text class="bb-end" style="fill:var(${cv})" x="${(xFor(ly) + 8).toFixed(1)}" y="${(yFor(d[ly]) + 3.5).toFixed(1)}">${esc(pl.split(" ").slice(-1)[0])}</text>`;
+    });
+
+    $("#lh-board").innerHTML = sel.length
+      ? `<svg class="bb-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Auction price by year">${grid}${lines}</svg>`
+      : `<div class="lh-boardempty">Tap a player below to chart their auction price.</div>`;
+    $("#lh-chips").querySelectorAll(".lh-chip").forEach((c) => c.classList.toggle("on", mvSel.has(c.dataset.p)));
+  }
+
+  /* --- 08 · Maestro & Wizard ---------------------------------------------- */
+  function renderManagerMap() {
+    const el = $("#lh-quad"); if (!el) return;
+    const pts = MONEY.retention.slice();
+    if (!pts.length) { el.innerHTML = ""; return; }
+    const xs = pts.map((p) => p.retPct), ys = pts.map((p) => p.winPct);
+    const xmin = Math.floor(Math.min(...xs) - 2), xmax = 100;
+    const ymin = Math.floor(Math.min(...ys) - 4), ymax = Math.ceil(Math.max(...ys) + 4);
+    const med = (a) => { const s = a.slice().sort((p, q) => p - q), m = s.length >> 1; return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2; };
+    const medX = med(xs), medY = med(ys);
+    const X = (v) => (v - xmin) / (xmax - xmin) * 100, Y = (v) => (1 - (v - ymin) / (ymax - ymin)) * 100;
+    const mxp = X(medX), myp = Y(medY), maxS = Math.max(...pts.map((p) => p.seasons));
+
+    let inner =
+      `<div class="lh-qzone maestro" style="left:${mxp}%;top:0;width:${100 - mxp}%;height:${myp}%"><span>The Maestro</span></div>` +
+      `<div class="lh-qzone wizard" style="left:0;top:0;width:${mxp}%;height:${myp}%"><span>The Wizard</span></div>` +
+      `<div class="lh-qzone forget" style="left:${mxp}%;top:${myp}%;width:${100 - mxp}%;height:${100 - myp}%"><span>Set &amp; Forget</span></div>` +
+      `<div class="lh-qzone adrift" style="left:0;top:${myp}%;width:${mxp}%;height:${100 - myp}%"><span>Adrift</span></div>` +
+      `<div class="lh-qx" style="left:${mxp}%"><span>med ${Math.round(medX)}%</span></div>` +
+      `<div class="lh-qy" style="top:${myp}%"><span>med ${Math.round(medY)}%</span></div>`;
+    pts.forEach((p) => {
+      const r = 9 + (p.seasons / maxS) * 9, c = OWNER_COLOR(p.owner);
+      inner += `<div class="lh-qpt" style="left:${X(p.retPct)}%;top:${Y(p.winPct)}%" data-o="${esc(p.owner)}">` +
+        `<span class="lh-qdot" style="width:${(r * 2).toFixed(0)}px;height:${(r * 2).toFixed(0)}px;background:${c};box-shadow:0 0 0 1.5px color-mix(in srgb,${c} 55%,transparent),0 0 16px -2px ${c}"></span>` +
+        `<span class="lh-qname">${p.owner}</span></div>`;
+    });
+
+    el.innerHTML =
+      `<div class="lh-qcorner tl">${Math.round(ymax)}%</div><div class="lh-qcorner bl">${Math.round(ymin)}%</div>` +
+      `<div class="lh-plot">${inner}</div>` +
+      `<div class="lh-qaxx">Auction-dollar retention &rarr; (${xmin}–100%)</div>` +
+      `<div class="lh-qaxy">Win rate &rarr;</div>`;
+
+    const plot = $(".lh-plot", el), byOwner = {}; pts.forEach((p) => byOwner[p.owner] = p);
+    plot.addEventListener("mousemove", (e) => {
+      const t = e.target.closest(".lh-qpt");
+      plot.querySelectorAll(".lh-qpt.hot").forEach((n) => { if (n !== t) n.classList.remove("hot"); });
+      if (!t) { hideTip(); return; }
+      t.classList.add("hot");
+      const p = byOwner[t.dataset.o];
+      tipAt(`<div class="lh-tth">${p.owner}</div>` +
+        `<div class="lh-ttrow"><b style="color:var(--lh-money-hi)">${Math.round(p.retPct)}%</b> of auction $ kept · <b style="color:var(--lh-gold-hi)">${Math.round(p.winPct)}%</b> win rate</div>` +
+        `<div class="lh-ttrow">$${p.retained} of $${p.spend} survived · ${p.seasons} seasons</div>`, e.clientX, e.clientY);
+    });
+    plot.addEventListener("mouseleave", () => { hideTip(); plot.querySelectorAll(".lh-qpt.hot").forEach((n) => n.classList.remove("hot")); });
+  }
+
   /* ---------------- interactions: grid tooltip + roster drawer ---------------- */
   function wireGrid(gridEl) {
     const tip = $("#lhTip");
@@ -414,12 +697,16 @@
     if (built) return;
     const host = $("#view-history");
     host.innerHTML = '<div class="lh-error">Loading the archive…</div>';
-    fetch(API).then((r) => r.json()).then((hist) => {
+    const grab = (url) => fetch(url).then((r) => r.json()).catch(() => null);
+    Promise.all([grab(API), grab(AUCTION_API), grab(OWNERS_API)]).then(([hist, auction, owners]) => {
       const seasons = (hist && hist.seasons) || [];
       if (!seasons.length) { host.innerHTML = '<div class="lh-error">No league history is available yet.</div>'; built = true; return; }
       DATA = derive(seasons);
+      MONEY = (auction && auction.seasons && Object.keys(auction.seasons).length) ? deriveMoney(seasons, auction.seasons) : null;
+      OWNER_COLOR = buildOwnerColor(owners);
       scaffold(host);
       renderBanners(); renderGrid(); renderRegime(); renderLoyalty(); renderLedger(); renderRoyalty();
+      if (MONEY) { renderSunkCosts(); renderBigBoard(); renderManagerMap(); }
       wireDrawerOnce();
       built = true;
     }).catch(() => { host.innerHTML = '<div class="lh-error">Couldn’t load the league history.</div>'; });

--- a/static/js/league-history.js
+++ b/static/js/league-history.js
@@ -131,13 +131,17 @@
       .map((o) => ({ owner: o, ...career[o], pct: winPct(career[o]), active: active.has(o) }))
       .sort((a, b) => b.pct - a.pct || (b.w - b.l) - (a.w - a.l) || a.owner.localeCompare(b.owner));
 
-    // league royalty: most-rostered NFL players ever
-    const pop = {};
+    // league royalty: most-rostered NFL players ever (with per-season appearances for the hover)
+    const pop = {}, popApp = {};
     seasons.forEach((s) => s.standings.forEach((t) => {
       const seen = new Set();
-      (t.roster || []).forEach((e) => { const p = e.player_name; if (skipPlayer(p) || seen.has(p)) return; seen.add(p); pop[p] = (pop[p] || 0) + 1; });
+      (t.roster || []).forEach((e) => {
+        const p = e.player_name; if (skipPlayer(p) || seen.has(p)) return; seen.add(p);
+        pop[p] = (pop[p] || 0) + 1;
+        (popApp[p] = popApp[p] || []).push({ year: s.year, owner: t.owner });
+      });
     }));
-    const royalty = Object.entries(pop).map(([player, n]) => ({ player, seasons: n })).sort((a, b) => b.seasons - a.seasons).slice(0, 12);
+    const royalty = Object.entries(pop).map(([player, n]) => ({ player, seasons: n, app: popApp[player] })).sort((a, b) => b.seasons - a.seasons).slice(0, 12);
 
     return {
       meta: { years, nSeasons: seasons.length, nManagers: Object.keys(appear).length, latest, active },
@@ -153,14 +157,16 @@
        retention  — career auction-dollar retention vs. win rate per owner   */
   function deriveMoney(seasons, auctionSeasons) {
     const winpctOf = (t) => { const g = (t.wins || 0) + (t.losses || 0) + (t.ties || 0); return g ? ((t.wins || 0) + 0.5 * (t.ties || 0)) / g : 0; };
-    const posOf = {}, rosterSet = {}, meta = {}, leagueByYear = {};
+    const posOf = {}, rosterSet = {}, meta = {}, leagueByYear = {}, ownersByYear = {};
     seasons.forEach((s) => {
       const champO = s.champion && s.champion.owner, runO = s.runner_up && s.runner_up.owner, shared = !!s.shared_title;
       const lset = leagueByYear[s.year] = new Set();
+      const olist = ownersByYear[s.year] = [];
       s.standings.forEach((t) => {
         const set = new Set();
         (t.roster || []).forEach((e) => { const nn = normName(e.player_name); set.add(nn); lset.add(nn); if (e.position) posOf[nn] = e.position; });
         rosterSet[`${s.year}|${t.owner}`] = set;
+        olist.push(t.owner);
         const isC = t.owner === champO || (shared && t.owner === runO);
         const isR = t.owner === runO && !shared;
         meta[`${s.year}|${t.owner}`] = {
@@ -188,12 +194,19 @@
           if (set && set.has(nn)) { r.retained += p.price; return; }
           if (!set) return;                                   // no roster to judge against
           const inLeague = (leagueByYear[y] || new Set()).has(nn);
+          // who finished the season with the player (the rival who claimed them off waivers)
+          let claimedBy = null;
+          if (inLeague) {
+            for (const o2 of (ownersByYear[y] || [])) {
+              if (o2 !== owner && rosterSet[`${y}|${o2}`] && rosterSet[`${y}|${o2}`].has(nn)) { claimedBy = o2; break; }
+            }
+          }
           burns.push({
             // a "burn" = an auction buy missing from the owner's end-of-season roster.
             // gone   = not on ANY roster at year's end (dropped, never re-rostered)
             // claimed = on a RIVAL's end-of-season roster (dropped, then picked up off waivers)
             year: y, owner, player: p.player, price: p.price, keeper: !!p.keeper,
-            gone: !inLeague, claimed: inLeague,
+            gone: !inLeague, claimed: inLeague, claimedBy,
             rec: m ? m.rec : "", win: m ? m.wins > m.losses : false,
             champ: m ? m.champ : false, runner: m ? m.runner : false,
           });
@@ -226,7 +239,7 @@
 
         <section class="lh-sec">
           <div class="lh-sec-head"><span class="lh-num">01</span><h2>Season by Season</h2></div>
-          <p class="lh-sub">Twenty-three years of finishes, one square each. <b>Gold is a title, bright is a top year, dark is a lean one</b> — a dynasty reads as a bright row, a slump as a dark stretch. Hover a name to follow one manager; the squares show regular-season finish and gold marks who actually won it. Click any square for that team's full roster.</p>
+          <p class="lh-sub">Twenty-three years of finishes, one square each. <b>Gold is a title, bright is a top year, dark is a lean one.</b> A dynasty reads as a bright row, a slump as a dark stretch. Hover a name to follow one manager; the squares show regular-season finish and gold marks who actually won it. Click any square for that team's full roster.</p>
           <div class="lh-gridcard">
             <div class="lh-grid" id="lh-grid"></div>
             <div class="lh-legend" id="lh-legend"></div>
@@ -235,27 +248,27 @@
 
         <section class="lh-sec">
           <div class="lh-sec-head"><span class="lh-num">02</span><h2>Best Records vs. Titles</h2></div>
-          <p class="lh-sub">Most seasons with the best regular-season record, against most championships won. They don't always go to the same manager — the gap between the two columns is the gap between dominant and decisive.</p>
+          <p class="lh-sub">Most seasons with the best regular-season record, against most championships won. They don't always go to the same manager. The gap between the two columns is the gap between dominant and decisive.</p>
           <div class="lh-talehead"><div class="l">Best records</div><div class="c">Manager</div><div class="r">Titles</div></div>
           <div class="lh-tale" id="lh-tale"></div>
         </section>
 
         <section class="lh-sec">
           <div class="lh-sec-head"><span class="lh-num">03</span><h2>Most-Rostered Player, by Manager</h2></div>
-          <p class="lh-sub">The player each manager kept coming back for — drafted or stashed, season after season — and how many seasons they rostered them.</p>
+          <p class="lh-sub">The player each manager kept coming back for, drafted or stashed, year after year.</p>
           <div class="lh-loyal" id="lh-loyal"></div>
         </section>
 
         <div class="lh-cols">
           <section class="lh-sec" style="margin-top:0">
             <div class="lh-sec-head"><span class="lh-num">04</span><h2>Career Win-Loss Records</h2></div>
-            <p class="lh-sub">Every manager's career regular-season record — <b>gold is wins, the rest is losses</b>, best rate on top. Three seasons or more.</p>
+            <p class="lh-sub">Every manager's career regular-season record. <b>Gold is wins, the rest is losses</b>, best rate on top. Three seasons or more.</p>
             <div id="lh-ledger"></div>
-            <p class="lh-foot">Regular-season games only — playoffs aren't counted. <b>Ties score as half a win.</b></p>
+            <p class="lh-foot">Regular-season games only. Playoffs aren't counted. <b>Ties score as half a win.</b></p>
           </section>
           <section class="lh-sec lh-roy" style="margin-top:0">
             <div class="lh-sec-head"><span class="lh-num">05</span><h2>Most-Rostered Players, League-Wide</h2></div>
-            <p class="lh-sub">The NFL names that defined the era — most seasons rostered by <i>anyone</i> in the league.</p>
+            <p class="lh-sub">The NFL names that defined the era: most seasons rostered by <i>anyone</i> in the league. Hover a bar for every season.</p>
             <div id="lh-royalty"></div>
           </section>
         </div>
@@ -405,7 +418,8 @@
     const ro = $("#lh-royalty"); ro.innerHTML = "";
     const maxR = DATA.royalty[0].seasons;
     DATA.royalty.forEach((p, i) => {
-      const row = ce("div", "lh-row");
+      const row = ce("div", "lh-row lh-hov");
+      row.dataset.i = i;
       row.innerHTML =
         `<div class="lh-nm">${p.player}</div>` +
         `<div class="lh-track"><span class="lh-fill ${i === 0 ? "gold" : "pew"}"></span></div>` +
@@ -413,6 +427,21 @@
       ro.appendChild(row);
       setTimeout(() => { $(".lh-fill", row).style.width = (p.seasons / maxR * 100) + "%"; }, 250 + i * 55);
     });
+    ro.addEventListener("mousemove", (e) => {
+      const row = e.target.closest(".lh-row"); if (!row || row.dataset.i == null) { hideTip(); return; }
+      tipAt(royaltyTip(DATA.royalty[+row.dataset.i]), e.clientX, e.clientY);
+    });
+    ro.addEventListener("mouseleave", hideTip);
+  }
+
+  // every season a player was rostered: year · team · owner · result
+  function royaltyTip(p) {
+    const rows = (p.app || []).slice().sort((a, b) => a.year - b.year).map((a) => {
+      const r = (DATA.rosters[a.owner] || {})[a.year] || {};
+      const res = r.champ ? '<b class="ch">✦</b>' : (r.runner ? '<b class="ru">RU</b>' : (r.rec || ""));
+      return `<div class="lh-ttline"><span class="lh-tty">’${String(a.year).slice(2)}</span>${r.team || "?"} · ${a.owner} · ${res}</div>`;
+    }).join("");
+    return `<div class="lh-tth">${p.player}</div><div class="lh-ttteam">${p.seasons} seasons rostered</div>${rows}`;
   }
 
   /* ================= Part II · The Money ================= */
@@ -428,14 +457,14 @@
 
        <section class="lh-sec">
          <div class="lh-sec-head"><span class="lh-num">06</span><h2>Priciest Dropped Players</h2></div>
-         <p class="lh-sub">The most expensive players who weren't on their manager's roster at season's end. <b>Charred bars were dropped and never re-rostered; amber bars were dropped, then claimed by a rival off waivers.</b> Glowing tags mark managers who <b>won anyway.</b></p>
+         <p class="lh-sub">The most expensive players who weren't on their manager's roster at season's end. <b>Charred bars were dropped and never re-rostered; amber bars were dropped, then claimed by a rival off waivers.</b> Glowing tags mark managers who <b>won anyway.</b> Hover a row to see who finished the year with the player.</p>
          <div class="lh-sunkcard"><div id="lh-sunk"></div></div>
          <p class="lh-foot">Keepers count as committed dollars. This counts any auction buy missing from the manager's end-of-season roster.</p>
        </section>
 
        <section class="lh-sec">
          <div class="lh-sec-head"><span class="lh-num">07</span><h2>Player Prices Over Time</h2></div>
-         <p class="lh-sub">What each player cost at auction, season by season &mdash; <b>lines are colored by position.</b> Four names are charted to start; tap any chip below to add or remove a line.</p>
+         <p class="lh-sub">What each player cost at auction, season by season. <b>Lines are colored by position.</b> Four names are charted to start; tap any chip below to add or remove a line.</p>
          <div class="lh-boardcard">
            <div class="lh-movers" id="lh-movers"></div>
            <div class="lh-board" id="lh-board"></div>
@@ -462,7 +491,8 @@
       const tag = b.champ ? `<span class="lh-btag champ">★ Champion</span>`
         : b.runner ? `<span class="lh-btag won">Runner-up</span>`
           : b.win ? `<span class="lh-btag won">Won anyway</span>` : "";
-      const row = ce("div", "lh-burn" + (b.gone ? " gone" : " claimed") + (b.win ? " winrec" : ""));
+      const row = ce("div", "lh-burn lh-hov" + (b.gone ? " gone" : " claimed") + (b.win ? " winrec" : ""));
+      row.dataset.i = i;
       row.innerHTML =
         `<div class="lh-bowner">${b.owner}</div>` +
         `<div class="lh-bmid">` +
@@ -475,6 +505,31 @@
       el.appendChild(row);
       setTimeout(() => { $(".lh-bfill", row).style.width = (b.price / maxP * 100) + "%"; }, 220 + i * 55);
     });
+    el.addEventListener("mousemove", (e) => {
+      const row = e.target.closest(".lh-burn"); if (!row || row.dataset.i == null) { hideTip(); return; }
+      tipAt(burnTip(MONEY.burns[+row.dataset.i]), e.clientX, e.clientY);
+    });
+    el.addEventListener("mouseleave", hideTip);
+  }
+
+  // who finished the season with the player, and the manager's result that year
+  function burnTip(b) {
+    const team = ((DATA.rosters[b.owner] || {})[b.year] || {}).team || "";
+    let end;
+    if (b.gone) {
+      end = `<div class="lh-ttline">Dropped, never re-rostered</div>`;
+    } else {
+      const ct = ((DATA.rosters[b.claimedBy] || {})[b.year] || {}).team || "";
+      end = b.claimedBy
+        ? `<div class="lh-ttline">Finished on <b>${b.claimedBy}</b>'s ${ct}</div>`
+        : `<div class="lh-ttline">Claimed off waivers by a rival</div>`;
+    }
+    const res = b.champ ? '<b class="ch">✦ champion</b>' : (b.runner ? '<b class="ru">runner-up</b>' : (b.win ? "winning record" : "missed the cut"));
+    return `<div class="lh-tth">${b.player}</div>` +
+      `<div class="lh-ttteam">${b.year} · ${b.owner}'s ${team}</div>` +
+      `<div class="lh-ttline">$${b.price} at auction${b.keeper ? " · keeper" : ""}</div>` +
+      end +
+      `<div class="lh-ttline">${b.owner} went ${b.rec} · ${res}</div>`;
   }
 
   /* --- 07 · Player Prices Over Time --------------------------------------- */

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -13,7 +13,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet">
     <link rel="stylesheet" href="/static/css/draft-set-viewer.css?v=4">
-    <link rel="stylesheet" href="/static/css/league-history.css?v=5">
+    <link rel="stylesheet" href="/static/css/league-history.css?v=6">
   </head>
   <body>
     <div id="app">
@@ -200,7 +200,7 @@
     </div>
     <div id="ptip"></div>
     <div id="vError" class="tb-empty verror-toast"></div>
-    <script src="/static/js/league-history.js?v=5"></script>
+    <script src="/static/js/league-history.js?v=6"></script>
     {# Hand-tuned single-line JS below; djlint's reformat collapses a // comment over later code. #}
     {# djlint:off #}
     <script>

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -13,7 +13,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet">
     <link rel="stylesheet" href="/static/css/draft-set-viewer.css?v=4">
-    <link rel="stylesheet" href="/static/css/league-history.css?v=4">
+    <link rel="stylesheet" href="/static/css/league-history.css?v=5">
   </head>
   <body>
     <div id="app">
@@ -200,7 +200,7 @@
     </div>
     <div id="ptip"></div>
     <div id="vError" class="tb-empty verror-toast"></div>
-    <script src="/static/js/league-history.js?v=4"></script>
+    <script src="/static/js/league-history.js?v=5"></script>
     {# Hand-tuned single-line JS below; djlint's reformat collapses a // comment over later code. #}
     {# djlint:off #}
     <script>

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -13,7 +13,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet">
     <link rel="stylesheet" href="/static/css/draft-set-viewer.css?v=4">
-    <link rel="stylesheet" href="/static/css/league-history.css?v=9">
+    <link rel="stylesheet" href="/static/css/league-history.css?v=10">
   </head>
   <body>
     <div id="app">
@@ -200,7 +200,7 @@
     </div>
     <div id="ptip"></div>
     <div id="vError" class="tb-empty verror-toast"></div>
-    <script src="/static/js/league-history.js?v=9"></script>
+    <script src="/static/js/league-history.js?v=10"></script>
     {# Hand-tuned single-line JS below; djlint's reformat collapses a // comment over later code. #}
     {# djlint:off #}
     <script>

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -13,7 +13,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet">
     <link rel="stylesheet" href="/static/css/draft-set-viewer.css?v=4">
-    <link rel="stylesheet" href="/static/css/league-history.css?v=8">
+    <link rel="stylesheet" href="/static/css/league-history.css?v=9">
   </head>
   <body>
     <div id="app">
@@ -200,7 +200,7 @@
     </div>
     <div id="ptip"></div>
     <div id="vError" class="tb-empty verror-toast"></div>
-    <script src="/static/js/league-history.js?v=8"></script>
+    <script src="/static/js/league-history.js?v=9"></script>
     {# Hand-tuned single-line JS below; djlint's reformat collapses a // comment over later code. #}
     {# djlint:off #}
     <script>

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -13,7 +13,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet">
     <link rel="stylesheet" href="/static/css/draft-set-viewer.css?v=4">
-    <link rel="stylesheet" href="/static/css/league-history.css?v=7">
+    <link rel="stylesheet" href="/static/css/league-history.css?v=8">
   </head>
   <body>
     <div id="app">
@@ -200,7 +200,7 @@
     </div>
     <div id="ptip"></div>
     <div id="vError" class="tb-empty verror-toast"></div>
-    <script src="/static/js/league-history.js?v=7"></script>
+    <script src="/static/js/league-history.js?v=8"></script>
     {# Hand-tuned single-line JS below; djlint's reformat collapses a // comment over later code. #}
     {# djlint:off #}
     <script>

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -13,7 +13,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet">
     <link rel="stylesheet" href="/static/css/draft-set-viewer.css?v=4">
-    <link rel="stylesheet" href="/static/css/league-history.css?v=6">
+    <link rel="stylesheet" href="/static/css/league-history.css?v=7">
   </head>
   <body>
     <div id="app">
@@ -200,7 +200,7 @@
     </div>
     <div id="ptip"></div>
     <div id="vError" class="tb-empty verror-toast"></div>
-    <script src="/static/js/league-history.js?v=6"></script>
+    <script src="/static/js/league-history.js?v=7"></script>
     {# Hand-tuned single-line JS below; djlint's reformat collapses a // comment over later code. #}
     {# djlint:off #}
     <script>


### PR DESCRIPTION
## Summary
- Adds a new **"Part II · The Money"** group to the League History tab of the read-only viewer (port 8176), continuing the existing numbered sections. Built with hand-rolled SVG/CSS to match the existing "hall-of-records" broadcast aesthetic — **no chart library, no API changes**.
- **§06 Sunk Costs** — biggest auction busts: money on players who weren't on the owner's end-of-season roster, with ember bars tagged `TRADED` (still in league) vs `GONE` (left the league), and glowing **WON ANYWAY / ★ CHAMPION** tags for winning teams. (e.g. Raman's $35 Chris Carson → traded → 12-2 title.)
- **§07 The Big Board** — SVG line chart of player auction prices across the seasons, lines colored by position, a "market movers" ticker (biggest run-ups/collapses), and toggleable player chips.
- **§08 Maestro & Wizard** (the signature) — quadrant scatter of career **auction-dollar retention % vs. regular-season win %**, owner tokens in team colors, median crosshair, and four named zones (Maestro / Wizard / Set & Forget / Adrift).
- Includes the **2025 season** auction data so the views span 2016–2025 (the year range auto-detects from the data).

## Implementation notes
- `league-history.js` now also fetches `/api/v1/auction-prices` and `/api/v1/owners`, derives the money views client-side, and joins auction prices to end-of-season rosters by **normalized player name**.
- **Data decisions:** keepers count as committed auction spend; a "burn" is any auction buy missing from the owner's end-of-season roster; **D/ST excluded** (not superstars, and their names rarely match across sources — caught a false `$37 JAX D/ST` burn).
- Join validated at **78–91% dollar-weighted** match (effectively perfect at the high-price end where it matters).
- No routes added/changed → `DESIGN.md`/`README.md`/OpenAPI need no updates.

## Test plan
- [ ] `uv run python main.py`, open the viewer at http://localhost:8176, click **League History**, scroll to "Part II · The Money".
- [ ] §06: verify ember bars, TRADED/GONE tags, and WON ANYWAY/CHAMPION highlights render.
- [ ] §07: toggle player chips and "Movers" entries — price lines add/remove; hover a point for the tooltip.
- [ ] §08: hover owner tokens for the retention/win detail; confirm quadrant labels + median crosshair.
- [ ] Resize to a phone width — confirm no horizontal overflow and the scatter tokens shrink/stay legible.
- [ ] `uv run ruff check src/`, `uv run djlint templates/` (one pre-existing unrelated `H020` warning expected).

## Links
- Builds on the auction-price archive from #50.