### PR TITLE
Fix League History GitHub Pages page styling (self-contained CSS)

### DIFF
--- a/docs/league-history.css
+++ b/docs/league-history.css
@@ -5,6 +5,42 @@
    .tag/.insight all exist), and colors reuse the viewer's design tokens.
    ========================================================================== */
 
+/* Base design tokens + page chrome. In the viewer these came from
+   draft-set-viewer.css (its :root) and the page's web-fonts; inlined here so the
+   standalone GitHub Pages page is fully self-contained. */
+:root {
+  --midnight: #16141A;
+  --deep: #211E27;
+  --deep2: #1A1820;
+  --line: #332F3A;
+  --line2: #48434F;
+  --ice: #F2EEE7;
+  --slate: #A09AA6;
+  --gold: #F4C152;
+  --turf: #34C06C;
+  --qb: #A877DE;
+  --rb: #46B86C;
+  --wr: #5790CF;
+  --te: #E08A45;
+  --k: #E6B23E;
+  --dst: #D6564A;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(1300px 560px at 50% -14%, rgba(224, 162, 74, .06), transparent 62%),
+    radial-gradient(1000px 640px at 100% 120%, rgba(54, 192, 108, .035), transparent 60%),
+    var(--midnight);
+  background-attachment: fixed;
+  color: var(--ice);
+  font-family: "Inter", system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
 #view-history,
 #lhDrawer,
 #lhTip {

--- a/docs/league_history.html
+++ b/docs/league_history.html
@@ -4,6 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>League History — The Rafters</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
+        rel="stylesheet">
   <link rel="stylesheet" href="league-history.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
The standalone `docs/league_history.html` (added in #54) rendered unstyled on GitHub Pages — white background, Times New Roman, no gold/silver theme.

**Root cause:** `league-history.css` was never self-contained. Its `--lh-*` tokens *map from* base design tokens (`--deep`, `--deep2`, `--line`, `--line2`, `--ice`, `--slate`, `--gold`, `--turf`, and the position colors `--qb`…`--dst`) that live in the viewer's `draft-set-viewer.css` `:root`. The page's dark background and web-fonts also came from the viewer's `<head>`. The standalone page loads *only* `league-history.css`, so every base token resolved to empty and the whole theme collapsed.

**Fix:** make the published page self-contained (as the spec intended):
- Inline a `:root` of the required base tokens + a dark `body` base (the `--midnight` background with its radial gradients, `--ice` text, Inter font) into `league-history.css`.
- Add the Google Fonts link (Anton / Saira Condensed / Inter) to `league_history.html`.

Pure additions — +36 lines of CSS, +4 lines of HTML. No JS or data changes.

## Verification
Served `docs/` from a local static server and checked computed styles + a screenshot:
- `body` background `#16141A` (midnight) with radial gradients — was transparent/white
- text `#F2EEE7` (ice) on dark — was black
- `--lh-gold` → `#F4C152`, `--lh-silver` → `#b3bcc6` — were empty
- section headings ice-colored in Anton — were black/Times
- full grid + banners + money charts render with no errors

## Test plan
- [x] Local static-server render (computed styles + screenshot) shows the full "Rafters" theme
- [ ] After merge: confirm https://abottchen.github.io/ffdrafttracker/league_history.html renders styled once Pages rebuilds