### PR TITLE
fix: address four correctness defects (D1-D4)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -141,13 +141,15 @@ This allows frontend to handle errors appropriately:
 **State Management Flow:**
 1. **Nominate** → **Bid** (optional, multiple) → **Draft** → Repeat
 2. Each operation validates the current state before modification
-3. All state changes are atomic and logged for audit trails
+3. All state changes are atomic
+
+**Budget Reserve Rule:** Both nominations and bids enforce the max-bid reserve — a team must be able to afford $1 per remaining open roster slot after the bid. Nominations by a team with a full roster are rejected.
 
 **Admin Operations:**
-- Reset entire draft state
+- Reset entire draft state (requires `expected_version` unless `force: true`)
 - Undo individual picks
 - Cancel nominations  
-- Direct player assignment (bypassing auction for keepers)
+- Direct player assignment (bypassing auction for keepers) — intentionally skips budget and position-max validation as the admin escape hatch
 
 **Data Export:**
 - CSV export for external analysis and record keeping

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -536,7 +536,7 @@
     "/api/v1/admin/draft": {
       "post": {
         "summary": "Admin Draft Player",
-        "description": "Admin-only endpoint to draft a player directly without auction.",
+        "description": "Admin-only endpoint to draft a player directly without auction.\n\nIntentionally skips budget and position-max validation \u2014 this is the\nadmin escape hatch for keepers and mid-draft corrections.",
         "operationId": "admin_draft_player_api_v1_admin_draft_post",
         "requestBody": {
           "content": {

--- a/main.py
+++ b/main.py
@@ -245,42 +245,38 @@ def check_version(current_version: int, expected_version: int) -> None:
 
 def generate_draft_csv() -> str:
     """Generate CSV content based on current draft state."""
+    import csv
+
     draft_state = load_draft_state()
     owners = load_owners()
     players = load_players()
 
-    # Create player lookup dictionary
     player_dict = {p.id: p for p in players}
-
-    # Sort owners by ID for consistent column ordering
     sorted_owner_ids = sorted(owners.keys())
 
-    # Create CSV content
     csv_output = io.StringIO()
+    writer = csv.writer(csv_output, quoting=csv.QUOTE_ALL)
 
-    # First row: Owner names followed by empty cells
-    first_row = []
+    # Row 1: owner names paired with empty cells
+    header_row = []
     for owner_id in sorted_owner_ids:
-        owner_name = owners[owner_id]["owner_name"]
-        first_row.extend([f'"{owner_name}"', '""'])
-    csv_output.write(",".join(first_row) + "\n")
+        header_row.extend([owners[owner_id]["owner_name"], ""])
+    writer.writerow(header_row)
 
-    # Second row: Alternating "Player" and "$"
-    second_row = []
+    # Row 2: alternating Player / $ sub-headers
+    sub_header = []
     for _ in sorted_owner_ids:
-        second_row.extend(['"Player"', '"$"'])
-    csv_output.write(",".join(second_row) + "\n")
+        sub_header.extend(["Player", "$"])
+    writer.writerow(sub_header)
 
-    # Find teams for each owner and get their picks
+    # Collect picks per owner
     owner_picks = {}
     for team in draft_state.teams:
         if team.owner_id in sorted_owner_ids:
             owner_picks[team.owner_id] = team.picks
 
-    # Determine maximum number of picks by any owner
     max_picks = max(len(picks) for picks in owner_picks.values()) if owner_picks else 0
 
-    # Generate data rows
     for pick_index in range(max_picks):
         row = []
         for owner_id in sorted_owner_ids:
@@ -289,16 +285,14 @@ def generate_draft_csv() -> str:
                 pick = picks[pick_index]
                 player = player_dict.get(pick.player_id)
                 if player:
-                    player_name = f"{player.last_name}, {player.first_name}"
-                    row.extend([f'"{player_name}"', str(pick.price)])
+                    name = f"{player.last_name}, {player.first_name}"
+                    row.extend([name, str(pick.price)])
                 else:
-                    row.extend(
-                        [f'"Unknown Player (ID: {pick.player_id})"', str(pick.price)]
-                    )
+                    name = f"Unknown Player (ID: {pick.player_id})"
+                    row.extend([name, str(pick.price)])
             else:
-                # Empty cells for owners with fewer picks
-                row.extend(['""', '""'])
-        csv_output.write(",".join(row) + "\n")
+                row.extend(["", ""])
+        writer.writerow(row)
 
     csv_content = csv_output.getvalue()
     csv_output.close()
@@ -605,6 +599,28 @@ async def nominate_player(request: NominateRequest):
             detail=f"Owner {request.owner_id} does not exist",
         )
 
+    # Find the nominating team and enforce the max-bid reserve rule.
+    team = next((t for t in draft_state.teams if t.owner_id == request.owner_id), None)
+    if team is not None:
+        mb = max_bid(team, config)
+        if mb is None:
+            raise HTTPException(
+                status_code=422,
+                detail="Roster is full; this team cannot nominate.",
+            )
+        if request.initial_bid > mb:
+            spots = remaining_roster_spots(team, config)
+            remaining_after = team.budget_remaining - request.initial_bid
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Insufficient budget. After ${request.initial_bid} bid, "
+                    f"you would have ${remaining_after} left but need "
+                    f"at least ${spots - 1} to fill remaining "
+                    f"{spots - 1} roster spots"
+                ),
+            )
+
     # Enforce position maximum for the nominating team (nomination opens a bid).
     players = load_players()
     player = next((p for p in players if p.id == request.player_id), None)
@@ -612,9 +628,6 @@ async def nominate_player(request: NominateRequest):
         max_at_pos = config.position_maximums.get(player.position)
         player_positions = {p.id: p.position for p in players}
         if max_at_pos is not None:
-            team = next(
-                (t for t in draft_state.teams if t.owner_id == request.owner_id), None
-            )
             if team is not None and (
                 position_count(team, player.position, player_positions) >= max_at_pos
             ):
@@ -828,8 +841,6 @@ async def complete_draft(request: DraftRequest):
         )
 
     # Create draft pick
-    from src.models import DraftPick
-
     # Generate pick ID (simplified - in production use UUID or database ID)
     max_pick_id = max(
         [p.pick_id for t in draft_state.teams for p in t.picks], default=0
@@ -845,7 +856,15 @@ async def complete_draft(request: DraftRequest):
     team.picks.append(pick)
     team.budget_remaining -= request.final_price
 
-    # Remove player from available
+    # Remove player from available (guard against data-integrity edge case)
+    if request.player_id not in draft_state.available_player_ids:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Data integrity error: player {request.player_id} is "
+                "not in the available player pool"
+            ),
+        )
     draft_state.available_player_ids.remove(request.player_id)
 
     # Clear nomination
@@ -889,7 +908,11 @@ async def complete_draft(request: DraftRequest):
 
 @app.post("/api/v1/admin/draft")
 async def admin_draft_player(request: AdminDraftRequest):
-    """Admin-only endpoint to draft a player directly without auction."""
+    """Admin-only endpoint to draft a player directly without auction.
+
+    Intentionally skips budget and position-max validation — this is the
+    admin escape hatch for keepers and mid-draft corrections.
+    """
     # Load current state
     draft_state = load_draft_state()
 
@@ -903,6 +926,19 @@ async def admin_draft_player(request: AdminDraftRequest):
         raise HTTPException(
             status_code=400,
             detail=f"Player {request.player_id} not found in players database",
+        )
+
+    # Reject if the player is currently nominated — cancel the nomination first.
+    if (
+        draft_state.nominated is not None
+        and draft_state.nominated.player_id == request.player_id
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Player {request.player_id} is currently nominated. "
+                "Cancel the nomination first."
+            ),
         )
 
     # Validate player is available for draft
@@ -1166,8 +1202,13 @@ async def reset_draft(request: ResetRequest):
     players = load_players()
     owners = load_owners()
 
-    # If not forcing, check version
-    if not request.force and request.expected_version is not None:
+    # If not forcing, require and check version
+    if not request.force:
+        if request.expected_version is None:
+            raise HTTPException(
+                status_code=422,
+                detail="expected_version is required unless force=true",
+            )
         current_state = load_draft_state()
         check_version(current_state.version, request.expected_version)
 

--- a/tests/integration/test_main_api.py
+++ b/tests/integration/test_main_api.py
@@ -289,15 +289,27 @@ class TestMainApiIntegration:
         state = self.client.get("/api/v1/draft-state").json()
         version_after_draft = state["version"]
 
-        # Try to nominate another player - this should succeed even with
-        # insufficient budget
-        # because budget validation happens during bidding, not nomination
+        # Owner 1 now has $20 left, 1 pick, 18 open slots → max_bid = 20 - 17 = $3.
+        # Nominating above max_bid is now rejected (D1 fix).
+        over_max_nominate = self.client.post(
+            "/api/v1/nominate",
+            json={
+                "owner_id": 1,
+                "player_id": 2,
+                "initial_bid": 15,
+                "expected_version": version_after_draft,
+            },
+        )
+        assert over_max_nominate.status_code == 422
+        assert "Insufficient budget" in over_max_nominate.json()["detail"]
+
+        # Nominating at the max bid ($3) succeeds.
         nominate_response = self.client.post(
             "/api/v1/nominate",
             json={
-                "owner_id": 1,  # This owner now has only $20 left
+                "owner_id": 1,
                 "player_id": 2,
-                "initial_bid": 15,  # Less than remaining budget
+                "initial_bid": 3,
                 "expected_version": version_after_draft,
             },
         )
@@ -306,23 +318,6 @@ class TestMainApiIntegration:
         # Get version after nomination
         state = self.client.get("/api/v1/draft-state").json()
         version_after_second_nominate = state["version"]
-
-        # Try to bid amount that would prevent roster completion - this should fail
-        # Owner 1 has $20 left and 1 player drafted, needs 18 more players
-        # If they bid $19, they'd have $1 left but need $17 more for remaining spots
-        bid_response = self.client.post(
-            "/api/v1/bid",
-            json={
-                "owner_id": 1,  # This owner has only $20 left, 1 player drafted
-                "bid_amount": 19,  # Would leave $1, need $17 for remaining spots
-                "expected_version": version_after_second_nominate,
-            },
-        )
-
-        # Should fail due to insufficient budget for roster completion
-        assert bid_response.status_code == 422
-        assert "Insufficient budget" in bid_response.json()["detail"]
-        assert "roster spots" in bid_response.json()["detail"]
 
         # Try a valid bid from owner 2 who has sufficient budget
         valid_bid_response = self.client.post(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1199,3 +1199,396 @@ class TestErrorHandling(TestMainApp):
             headers={"Content-Type": "application/json"},
         )
         assert response.status_code == 422
+
+
+class TestD1NominationMaxBid(TestMainApp):
+    """D1: Nomination initial bid must respect the max-bid reserve rule."""
+
+    @patch("main.load_draft_state")
+    @patch("main.load_owners")
+    @patch("main.load_configuration")
+    def test_nominate_422_initial_bid_exceeds_max_bid(
+        self, mock_config, mock_owners, mock_draft_state
+    ):
+        """Nominating with initial_bid above max_bid is rejected."""
+        mock_config.return_value = Configuration(
+            initial_budget=200, min_bid=1, position_maximums={}, total_rounds=19
+        )
+        mock_owners.return_value = self.sample_owners
+
+        # Team with $5 remaining and 5 open slots → max_bid = 5 - 4 = $1
+        existing_picks = [
+            DraftPick(pick_id=i, player_id=i + 10, owner_id=1, price=10)
+            for i in range(14)
+        ]
+        tight_team = Team(owner_id=1, budget_remaining=5, picks=existing_picks)
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            teams=[tight_team, self.sample_teams[1]]
+        )
+
+        response = self.client.post(
+            "/api/v1/nominate",
+            json={
+                "owner_id": 1,
+                "player_id": 1,
+                "initial_bid": 5,
+                "expected_version": 5,
+            },
+        )
+
+        assert response.status_code == 422
+        assert "Insufficient budget" in response.json()["detail"]
+
+    @patch("main.load_draft_state")
+    @patch("main.load_owners")
+    @patch("main.load_configuration")
+    def test_nominate_at_exact_max_bid_succeeds(
+        self, mock_config, mock_owners, mock_draft_state
+    ):
+        """Nominating at exactly max_bid succeeds."""
+        mock_config.return_value = Configuration(
+            initial_budget=200, min_bid=1, position_maximums={}, total_rounds=19
+        )
+        mock_owners.return_value = self.sample_owners
+
+        # Team with $5 remaining and 5 open slots → max_bid = $1
+        existing_picks = [
+            DraftPick(pick_id=i, player_id=i + 10, owner_id=1, price=10)
+            for i in range(14)
+        ]
+        tight_team = Team(owner_id=1, budget_remaining=5, picks=existing_picks)
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            teams=[tight_team, self.sample_teams[1]]
+        )
+
+        response = self.client.post(
+            "/api/v1/nominate",
+            json={
+                "owner_id": 1,
+                "player_id": 1,
+                "initial_bid": 1,
+                "expected_version": 5,
+            },
+        )
+
+        assert response.status_code == 200
+
+    @patch("main.load_draft_state")
+    @patch("main.load_owners")
+    @patch("main.load_configuration")
+    def test_nominate_422_roster_full(self, mock_config, mock_owners, mock_draft_state):
+        """Nominating when roster is full is rejected."""
+        mock_config.return_value = Configuration(
+            initial_budget=200, min_bid=1, position_maximums={}, total_rounds=19
+        )
+        mock_owners.return_value = self.sample_owners
+
+        # Team with full roster (19 picks = total_rounds)
+        existing_picks = [
+            DraftPick(pick_id=i, player_id=i + 10, owner_id=1, price=10)
+            for i in range(19)
+        ]
+        full_team = Team(owner_id=1, budget_remaining=10, picks=existing_picks)
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            teams=[full_team, self.sample_teams[1]]
+        )
+
+        response = self.client.post(
+            "/api/v1/nominate",
+            json={
+                "owner_id": 1,
+                "player_id": 1,
+                "initial_bid": 1,
+                "expected_version": 5,
+            },
+        )
+
+        assert response.status_code == 422
+        assert "Roster is full" in response.json()["detail"]
+
+
+class TestD2AdminDraftNominatedPlayer(TestMainApp):
+    """D2: admin_draft must reject the currently nominated player."""
+
+    @patch("main.load_draft_state")
+    @patch("main.load_players")
+    def test_admin_draft_422_player_currently_nominated(
+        self, mock_players, mock_draft_state
+    ):
+        """Admin-drafting the currently nominated player is rejected."""
+        mock_players.return_value = self.sample_players
+        nomination = Nominated(
+            player_id=1, current_bidder_id=1, nominating_owner_id=1, current_bid=10
+        )
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            nominated=nomination
+        )
+
+        response = self.client.post(
+            "/api/v1/admin/draft",
+            json={
+                "owner_id": 2,
+                "player_id": 1,
+                "price": 25,
+                "expected_version": 5,
+            },
+        )
+
+        assert response.status_code == 422
+        assert "Cancel the nomination first" in response.json()["detail"]
+        # State should not be saved
+        mock_draft_state.return_value.save_to_file.assert_not_called()
+
+    @patch("main.load_draft_state")
+    @patch("main.load_configuration")
+    @patch("main.load_players")
+    @patch("main.load_owners")
+    def test_admin_draft_different_player_during_nomination_succeeds(
+        self, mock_owners, mock_players, mock_config, mock_draft_state
+    ):
+        """Admin-drafting a different player while a nomination is active succeeds."""
+        mock_config.return_value = Configuration(
+            initial_budget=200, min_bid=1, position_maximums={}, total_rounds=17
+        )
+        mock_owners.return_value = self.sample_owners
+        mock_players.return_value = self.sample_players
+        nomination = Nominated(
+            player_id=1, current_bidder_id=1, nominating_owner_id=1, current_bid=10
+        )
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            nominated=nomination
+        )
+
+        response = self.client.post(
+            "/api/v1/admin/draft",
+            json={
+                "owner_id": 2,
+                "player_id": 3,
+                "price": 25,
+                "expected_version": 5,
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    @patch("main.load_draft_state")
+    @patch("main.load_configuration")
+    @patch("main.load_players")
+    @patch("main.load_owners")
+    def test_complete_draft_422_player_missing_from_available(
+        self, mock_owners, mock_players, mock_config, mock_draft_state
+    ):
+        """complete_draft returns 422 (not 500) when player missing from pool."""
+        mock_config.return_value = Configuration(
+            initial_budget=200, min_bid=1, position_maximums={}, total_rounds=19
+        )
+        mock_owners.return_value = self.sample_owners
+        mock_players.return_value = self.sample_players
+        nomination = Nominated(
+            player_id=1, current_bidder_id=2, nominating_owner_id=1, current_bid=20
+        )
+        # Player 1 is nominated but NOT in available_player_ids (data integrity issue)
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            nominated=nomination,
+            available_player_ids=[3],
+        )
+
+        response = self.client.post(
+            "/api/v1/draft",
+            json={
+                "owner_id": 2,
+                "player_id": 1,
+                "final_price": 20,
+                "expected_version": 5,
+            },
+        )
+
+        assert response.status_code == 422
+        assert "not in the available player pool" in response.json()["detail"]
+
+
+class TestD3ResetVersionGuard(TestMainApp):
+    """D3: reset_draft must require expected_version unless force=True."""
+
+    @patch("main.load_draft_state")
+    def test_reset_422_no_version_no_force(self, mock_draft_state):
+        """Reset with empty body (no version, no force) returns 422."""
+        mock_draft_state.return_value = self.sample_draft_state
+
+        response = self.client.post("/api/v1/reset", json={})
+
+        assert response.status_code == 422
+        assert "expected_version is required" in response.json()["detail"]
+
+    @patch("main.load_draft_state")
+    def test_reset_force_true_no_version_succeeds(self, mock_draft_state):
+        """Reset with force=true and no version succeeds."""
+        mock_draft_state.return_value = self.sample_draft_state
+
+        with (
+            patch("main.load_configuration") as mock_config,
+            patch("main.load_players") as mock_players,
+            patch("main.load_owners") as mock_owners,
+            patch("main.DraftState") as mock_draft_class,
+        ):
+            mock_config.return_value = MagicMock(initial_budget=200)
+            mock_players.return_value = self.sample_players
+            mock_owners.return_value = self.sample_owners
+
+            mock_initial_state = MagicMock()
+            mock_draft_class.return_value = mock_initial_state
+
+            response = self.client.post("/api/v1/reset", json={"force": True})
+
+            assert response.status_code == 200
+            assert response.json()["success"] is True
+
+    @patch("main.load_draft_state")
+    def test_reset_correct_version_succeeds(self, mock_draft_state):
+        """Reset with correct expected_version succeeds."""
+        mock_draft_state.return_value = self.sample_draft_state
+
+        with (
+            patch("main.load_configuration") as mock_config,
+            patch("main.load_players") as mock_players,
+            patch("main.load_owners") as mock_owners,
+            patch("main.DraftState") as mock_draft_class,
+        ):
+            mock_config.return_value = MagicMock(initial_budget=200)
+            mock_players.return_value = self.sample_players
+            mock_owners.return_value = self.sample_owners
+
+            mock_initial_state = MagicMock()
+            mock_draft_class.return_value = mock_initial_state
+
+            response = self.client.post("/api/v1/reset", json={"expected_version": 5})
+
+            assert response.status_code == 200
+            assert response.json()["success"] is True
+
+    @patch("main.load_draft_state")
+    def test_reset_stale_version_409(self, mock_draft_state):
+        """Reset with stale expected_version returns 409."""
+        mock_draft_state.return_value = self.sample_draft_state
+
+        with (
+            patch("main.load_configuration") as mock_config,
+            patch("main.load_players") as mock_players,
+            patch("main.load_owners") as mock_owners,
+        ):
+            mock_config.return_value = MagicMock(initial_budget=200)
+            mock_players.return_value = self.sample_players
+            mock_owners.return_value = self.sample_owners
+
+            response = self.client.post("/api/v1/reset", json={"expected_version": 3})
+
+            assert response.status_code == 409
+            assert "Draft state has changed" in response.json()["detail"]
+
+
+class TestD4CsvExport(TestMainApp):
+    """D4: CSV export must handle special characters safely."""
+
+    @patch("main.load_players")
+    @patch("main.load_owners")
+    @patch("main.load_draft_state")
+    def test_csv_handles_quotes_and_commas_in_names(
+        self, mock_draft_state, mock_owners, mock_players
+    ):
+        """CSV export round-trips names with embedded quotes and commas."""
+        import csv
+
+        tricky_players = [
+            Player(
+                id=1,
+                first_name='O\'Brien "OB"',
+                last_name="Jr, III",
+                team="BUF",
+                position="QB",
+            ),
+        ]
+        tricky_owners = {
+            1: {
+                "owner_name": 'Rick "C-137" Sanchez',
+                "team_name": "Portal, Gunners",
+            },
+        }
+
+        teams_with_picks = [
+            Team(
+                owner_id=1,
+                budget_remaining=175,
+                picks=[DraftPick(pick_id=1, player_id=1, owner_id=1, price=25)],
+            ),
+        ]
+
+        mock_players.return_value = tricky_players
+        mock_owners.return_value = tricky_owners
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            nominated=None, available_player_ids=[], teams=teams_with_picks
+        )
+
+        response = self.client.get("/api/v1/export/csv")
+        assert response.status_code == 200
+
+        csv_content = response.content.decode("utf-8")
+        reader = csv.reader(csv_content.strip().splitlines())
+        rows = list(reader)
+
+        # Header row should have the owner name intact
+        assert rows[0][0] == 'Rick "C-137" Sanchez'
+        # Data row should have the player name intact
+        assert rows[2][0] == 'Jr, III, O\'Brien "OB"'
+        assert rows[2][1] == "25"
+
+    @patch("main.load_players")
+    @patch("main.load_owners")
+    @patch("main.load_draft_state")
+    def test_csv_normal_output_structure_preserved(
+        self, mock_draft_state, mock_owners, mock_players
+    ):
+        """CSV export preserves the expected column layout."""
+        import csv
+
+        mock_players.return_value = self.sample_players
+        mock_owners.return_value = self.sample_owners
+
+        teams_with_picks = [
+            Team(
+                owner_id=1,
+                budget_remaining=185,
+                picks=[DraftPick(pick_id=1, player_id=1, owner_id=1, price=15)],
+            ),
+            Team(
+                owner_id=2,
+                budget_remaining=180,
+                picks=[DraftPick(pick_id=2, player_id=2, owner_id=2, price=20)],
+            ),
+        ]
+
+        mock_draft_state.return_value = self.create_mock_draft_state(
+            nominated=None, available_player_ids=[3], teams=teams_with_picks
+        )
+
+        response = self.client.get("/api/v1/export/csv")
+        assert response.status_code == 200
+
+        csv_content = response.content.decode("utf-8")
+        reader = csv.reader(csv_content.strip().splitlines())
+        rows = list(reader)
+
+        # Row 0: owner names with empty second column each
+        assert rows[0][0] == "Rick Sanchez"
+        assert rows[0][1] == ""
+        assert rows[0][2] == "Morty Smith"
+        assert rows[0][3] == ""
+
+        # Row 1: Player/$ headers
+        assert rows[1] == ["Player", "$", "Player", "$"]
+
+        # Row 2: pick data
+        assert rows[2][0] == "Allen, Josh"
+        assert rows[2][1] == "15"
+        assert rows[2][2] == "McCaffrey, Christian"
+        assert rows[2][3] == "20"


### PR DESCRIPTION
## Summary
- **D1**: Nomination initial bid now enforces the max-bid reserve rule — prevents teams from overbidding into an unrecoverable state, and rejects nominations by teams with full rosters
- **D2**: `admin_draft` rejects the currently nominated player (422) instead of creating a dangling nomination; `complete_draft` returns 422 instead of unhandled 500 when the player is missing from the available pool
- **D3**: `reset_draft` now requires `expected_version` unless `force=true` — previously an empty body bypassed the version check entirely
- **D4**: CSV export rewritten with `csv.writer` to properly handle embedded quotes, commas, and special characters in player/owner names
- Added intentional-permissiveness docstring to `admin_draft_player`, removed dead local import, updated DESIGN.md and regenerated OpenAPI docs

## Test plan
- [x] 12 new unit tests covering all four defects (3 for D1, 3 for D2, 4 for D3, 2 for D4)
- [x] Updated integration test for budget validation to reflect D1 behavior change
- [x] Full test suite passes (330 tests)
- [x] E2E draft workflow test passes
- [x] Ruff lint + format clean
- [x] Verify frontend reset button still works (sends `{ force: true }`, unaffected by D3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)