### PR TITLE
refactor: extract duplicated helpers and standardize API status codes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -111,12 +111,14 @@ To prevent double-submissions and race conditions, all state-modifying endpoints
 
 The API uses semantic HTTP status codes to distinguish different error scenarios:
 
-- **400 Bad Request:** Invalid input data (missing required fields, malformed JSON, invalid IDs)
+- **400 Bad Request:** Truly malformed input (invalid ETag format, price <= 0)
+- **404 Not Found:** Resource addressed by URL path does not exist (owner by ID, team by ID, pick by ID)
 - **409 Conflict:** Version mismatch due to concurrent modification
-- **422 Unprocessable Entity:** Business rule violations (insufficient budget, position limits, etc.)
+- **422 Unprocessable Entity:** Body-referenced entity validation failures (owner_id/player_id in request body not found, business rule violations such as insufficient budget, position limits, etc.)
 
 This allows frontend to handle errors appropriately:
 - 400 → Log error (shouldn't happen with proper frontend validation)
+- 404 → Resource not found at the given URL
 - 409 → Automatically refresh state and retry
 - 422 → Display specific error message to user
 

--- a/src/api/admin_routes.py
+++ b/src/api/admin_routes.py
@@ -17,9 +17,10 @@ from src.api.schemas import (
     TeamUpdateRequest,
 )
 from src.draft_rules import (
+    check_position_limit,
     max_bid,
     next_eligible_nominator,
-    position_count,
+    next_pick_id,
     remaining_roster_spots,
 )
 from src.models import DraftPick, DraftState, Nominated, Team
@@ -47,6 +48,20 @@ def check_version(current_version: int, expected_version: int) -> None:
                 f"Draft state has changed (version {current_version} != "
                 f"{expected_version}). Please refresh and try again."
             ),
+        )
+
+
+def parse_etag_version(if_match: str) -> int:
+    """Extract the integer version from an ``If-Match`` ETag header.
+
+    Raises ``HTTPException(400)`` when the value is not a valid integer.
+    """
+    try:
+        return int(if_match.strip('"'))
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail="If-Match header must contain a valid version number",
         )
 
 
@@ -163,7 +178,7 @@ async def nominate_player(request: NominateRequest):
         owners = load_owners()
         if request.owner_id not in owners:
             raise HTTPException(
-                status_code=400,
+                status_code=422,
                 detail=f"Owner {request.owner_id} does not exist",
             )
 
@@ -197,21 +212,9 @@ async def nominate_player(request: NominateRequest):
         players = load_players()
         player = next((p for p in players if p.id == request.player_id), None)
         if player is not None:
-            max_at_pos = config.position_maximums.get(player.position)
-            player_positions = {p.id: p.position for p in players}
-            if max_at_pos is not None:
-                if team is not None and (
-                    position_count(team, player.position, player_positions)
-                    >= max_at_pos
-                ):
-                    raise HTTPException(
-                        status_code=422,
-                        detail=(
-                            f"Team is already at the maximum of "
-                            f"{max_at_pos} players at the "
-                            f"{player.position} position"
-                        ),
-                    )
+            pos_err = check_position_limit(team, player, players, config)
+            if pos_err is not None:
+                raise HTTPException(status_code=422, detail=pos_err)
 
         # Create nomination
         draft_state.nominated = Nominated(
@@ -321,21 +324,9 @@ async def place_bid(request: BidRequest):
             None,
         )
         if player is not None:
-            max_at_pos = config.position_maximums.get(player.position)
-            if max_at_pos is not None:
-                player_positions = {p.id: p.position for p in players}
-                if (
-                    position_count(team, player.position, player_positions)
-                    >= max_at_pos
-                ):
-                    raise HTTPException(
-                        status_code=422,
-                        detail=(
-                            f"Team is already at the maximum of "
-                            f"{max_at_pos} players at the "
-                            f"{player.position} position"
-                        ),
-                    )
+            pos_err = check_position_limit(team, player, players, config)
+            if pos_err is not None:
+                raise HTTPException(status_code=422, detail=pos_err)
 
         # Update bid
         previous_bid = draft_state.nominated.current_bid
@@ -436,12 +427,8 @@ async def complete_draft(request: DraftRequest):
             )
 
         # Create draft pick
-        max_pick_id = max(
-            [p.pick_id for t in draft_state.teams for p in t.picks],
-            default=0,
-        )
         pick = DraftPick(
-            pick_id=max_pick_id + 1,
+            pick_id=next_pick_id(draft_state),
             player_id=request.player_id,
             owner_id=request.owner_id,
             price=request.final_price,
@@ -524,7 +511,7 @@ async def admin_draft_player(request: AdminDraftRequest):
         player = next((p for p in players if p.id == request.player_id), None)
         if not player:
             raise HTTPException(
-                status_code=400,
+                status_code=422,
                 detail=(f"Player {request.player_id} not found in players database"),
             )
 
@@ -552,7 +539,7 @@ async def admin_draft_player(request: AdminDraftRequest):
         owners = load_owners()
         if request.owner_id not in owners:
             raise HTTPException(
-                status_code=400,
+                status_code=422,
                 detail=f"Owner {request.owner_id} not found",
             )
 
@@ -575,11 +562,8 @@ async def admin_draft_player(request: AdminDraftRequest):
             )
 
         # Create draft pick
-        all_picks = [pick for team in draft_state.teams for pick in team.picks]
-        pick_id = max([pick.pick_id for pick in all_picks], default=0) + 1
-
         pick = DraftPick(
-            pick_id=pick_id,
+            pick_id=next_pick_id(draft_state),
             player_id=request.player_id,
             owner_id=request.owner_id,
             price=request.price,
@@ -679,15 +663,7 @@ async def cancel_nomination(
         draft_state = load_draft_state()
 
         # Parse ETag and check version for optimistic locking
-        try:
-            expected_version = int(if_match.strip('"'))
-        except ValueError:
-            raise HTTPException(
-                status_code=400,
-                detail=("If-Match header must contain a valid version number"),
-            )
-
-        # Check version
+        expected_version = parse_etag_version(if_match)
         check_version(draft_state.version, expected_version)
 
         # Validate nomination exists
@@ -735,14 +711,7 @@ async def remove_draft_pick(
         draft_state = load_draft_state()
 
         # Parse ETag and check version for optimistic locking
-        try:
-            expected_version = int(if_match.strip('"'))
-        except ValueError:
-            raise HTTPException(
-                status_code=400,
-                detail=("If-Match header must contain a valid version number"),
-            )
-
+        expected_version = parse_etag_version(if_match)
         check_version(draft_state.version, expected_version)
 
         # Find the pick and team

--- a/src/draft_rules.py
+++ b/src/draft_rules.py
@@ -1,6 +1,6 @@
 """Pure draft-math helpers. No file I/O: callers pass loaded state/config in."""
 
-from src.models import Configuration, DraftState, Team
+from src.models import Configuration, DraftState, Player, Team
 
 
 def remaining_roster_spots(team: Team, config: Configuration) -> int:
@@ -25,6 +25,48 @@ def position_count(team: Team, position: str, player_positions: dict[int, str]) 
     via the supplied lookup (e.g. {p.id: p.position for p in players})."""
     return sum(
         1 for pick in team.picks if player_positions.get(pick.player_id) == position
+    )
+
+
+def check_position_limit(
+    team: Team | None,
+    player: Player,
+    players: list[Player],
+    config: Configuration,
+) -> str | None:
+    """Return an error message if *team* is at the position maximum for
+    *player*'s position, or ``None`` if the pick is allowed.
+
+    Returns ``None`` immediately when *team* is ``None`` (unknown team)
+    or the position has no configured cap.
+    """
+    if team is None:
+        return None
+    max_at_pos = config.position_maximums.get(player.position)
+    if max_at_pos is None:
+        return None
+    player_positions = {p.id: p.position for p in players}
+    if position_count(team, player.position, player_positions) >= max_at_pos:
+        return (
+            f"Team is already at the maximum of "
+            f"{max_at_pos} players at the "
+            f"{player.position} position"
+        )
+    return None
+
+
+def next_pick_id(state: DraftState) -> int:
+    """Return the next available pick ID across all teams.
+
+    Equals ``max(pick_id across all teams) + 1``, defaulting to 1 when
+    no picks exist yet.
+    """
+    return (
+        max(
+            (p.pick_id for t in state.teams for p in t.picks),
+            default=0,
+        )
+        + 1
     )
 
 

--- a/tests/unit/test_draft_rules.py
+++ b/tests/unit/test_draft_rules.py
@@ -1,10 +1,12 @@
 from src.draft_rules import (
+    check_position_limit,
     max_bid,
     next_eligible_nominator,
+    next_pick_id,
     position_count,
     remaining_roster_spots,
 )
-from src.models import Configuration, DraftPick, DraftState, Team
+from src.models import Configuration, DraftPick, DraftState, Player, Team
 
 
 def _config(total_rounds=17):
@@ -149,3 +151,112 @@ class TestNextEligibleNominator:
         state = _state([_team(200, 0, 1), _team(0, 17, 2)])
         nxt = next_eligible_nominator(state, _config(17), from_id=1, inclusive=False)
         assert nxt == 1
+
+
+class TestCheckPositionLimit:
+    def _player(self, pid=1, position="RB"):
+        return Player(
+            id=pid,
+            first_name="Test",
+            last_name="Player",
+            team="BUF",
+            position=position,
+        )
+
+    def _players(self, *positions):
+        return [
+            Player(
+                id=i + 1,
+                first_name="P",
+                last_name=f"{i}",
+                team="BUF",
+                position=pos,
+            )
+            for i, pos in enumerate(positions)
+        ]
+
+    def test_returns_none_when_team_is_none(self):
+        player = self._player()
+        assert check_position_limit(None, player, [player], _config()) is None
+
+    def test_returns_none_when_position_has_no_cap(self):
+        # Position "FLEX" is not in position_maximums
+        cfg = Configuration(
+            initial_budget=200,
+            min_bid=1,
+            position_maximums={"QB": 3},
+            total_rounds=17,
+        )
+        player = self._player(position="RB")
+        team = _team(200, 0)
+        assert check_position_limit(team, player, [player], cfg) is None
+
+    def test_returns_none_when_under_limit(self):
+        players = self._players("RB", "RB", "WR")
+        team = Team(
+            owner_id=1,
+            budget_remaining=100,
+            picks=[
+                DraftPick(pick_id=1, player_id=1, owner_id=1, price=5),
+            ],
+        )
+        new_player = self._player(pid=4, position="RB")
+        # 1 RB on team, max is 8 -> OK
+        assert check_position_limit(team, new_player, players, _config()) is None
+
+    def test_returns_error_when_at_limit(self):
+        # Config has QB max = 3
+        players = self._players("QB", "QB", "QB")
+        team = Team(
+            owner_id=1,
+            budget_remaining=100,
+            picks=[
+                DraftPick(pick_id=i + 1, player_id=i + 1, owner_id=1, price=5)
+                for i in range(3)
+            ],
+        )
+        new_qb = self._player(pid=10, position="QB")
+        result = check_position_limit(team, new_qb, players, _config())
+        assert result is not None
+        assert "maximum of 3" in result
+        assert "QB" in result
+
+
+class TestNextPickId:
+    def test_returns_one_when_no_picks(self):
+        state = _state([_team(200, 0, 1), _team(200, 0, 2)])
+        assert next_pick_id(state) == 1
+
+    def test_returns_max_plus_one(self):
+        teams = [
+            Team(
+                owner_id=1,
+                budget_remaining=100,
+                picks=[
+                    DraftPick(pick_id=1, player_id=10, owner_id=1, price=5),
+                    DraftPick(pick_id=3, player_id=11, owner_id=1, price=5),
+                ],
+            ),
+            Team(
+                owner_id=2,
+                budget_remaining=100,
+                picks=[
+                    DraftPick(pick_id=2, player_id=12, owner_id=2, price=5),
+                ],
+            ),
+        ]
+        state = _state(teams)
+        assert next_pick_id(state) == 4
+
+    def test_single_pick(self):
+        teams = [
+            Team(
+                owner_id=1,
+                budget_remaining=100,
+                picks=[
+                    DraftPick(pick_id=5, player_id=10, owner_id=1, price=5),
+                ],
+            ),
+        ]
+        state = _state(teams)
+        assert next_pick_id(state) == 6

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -900,8 +900,8 @@ class TestPostEndpoints(TestMainApp):
 
     @patch("src.api.admin_routes.load_draft_state")
     @patch("src.api.admin_routes.load_players")
-    def test_admin_draft_400_player_not_found(self, mock_players, mock_draft_state):
-        """Test POST /api/v1/admin/draft returns 400 for player not in database."""
+    def test_admin_draft_422_player_not_found(self, mock_players, mock_draft_state):
+        """Test POST /api/v1/admin/draft returns 422 for player not in database."""
         mock_players.return_value = self.sample_players  # Only players 1, 2, 3
         mock_draft_state.return_value = self.create_mock_draft_state(
             available_player_ids=[
@@ -921,16 +921,16 @@ class TestPostEndpoints(TestMainApp):
             },
         )
 
-        assert response.status_code == 400
+        assert response.status_code == 422
         assert "Player 999 not found in players database" in response.json()["detail"]
 
     @patch("src.api.admin_routes.load_draft_state")
     @patch("src.api.admin_routes.load_players")
     @patch("src.api.admin_routes.load_owners")
-    def test_admin_draft_400_owner_not_found(
+    def test_admin_draft_422_owner_not_found(
         self, mock_owners, mock_players, mock_draft_state
     ):
-        """Test POST /api/v1/admin/draft returns 400 for invalid owner."""
+        """Test POST /api/v1/admin/draft returns 422 for invalid owner."""
         mock_players.return_value = self.sample_players
         mock_owners.return_value = self.sample_owners
         mock_draft_state.return_value = self.create_mock_draft_state()
@@ -945,7 +945,7 @@ class TestPostEndpoints(TestMainApp):
             },
         )
 
-        assert response.status_code == 400
+        assert response.status_code == 422
         assert "Owner 999 not found" in response.json()["detail"]
 
     @patch("src.api.admin_routes.load_draft_state")


### PR DESCRIPTION
## Summary
**R3 — Helper extraction:**
- `check_position_limit()` in `draft_rules.py` — replaces duplicated position-max checks in `nominate_player` and `place_bid`
- `next_pick_id()` in `draft_rules.py` — replaces duplicated pick-ID generation in `complete_draft` and `admin_draft_player`
- `parse_etag_version()` in `admin_routes.py` — replaces duplicated If-Match ETag parsing in `cancel_nomination` and `remove_draft_pick`
- 7 new unit tests for the extracted helpers

**R4 — API convention standardization:**
- Owner/player not found via request body fields: 400 → 422 (body-referenced entity validation)
- Convention documented in DESIGN.md: 404 for URL-path resources, 422 for body-referenced entities, 400 for malformed input, 409 for version conflicts
- Updated test assertions to match new status codes

## Test plan
- [x] 320 tests pass (7 new helper tests)
- [x] Ruff lint + format clean
- [x] OpenAPI docs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)