### PR TITLE
cleanup: type PlayerStats as numeric, fix CORS, add data-drop warnings

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,13 +24,12 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# Add CORS middleware for development
+# LAN-only tool; no auth/cookies.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Configure appropriately for production
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=["*"],
+    allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "If-Match"],
 )
 
 # Set up paths
@@ -94,13 +93,11 @@ viewer_app = FastAPI(
     version="1.0.0",
 )
 
-# Add CORS for viewer app
 viewer_app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "OPTIONS"],
+    allow_headers=["Content-Type", "If-Match"],
 )
 
 # Mount static files for viewer app (same as main app)

--- a/src/api/admin_routes.py
+++ b/src/api/admin_routes.py
@@ -96,6 +96,11 @@ def generate_draft_csv() -> str:
     for team in draft_state.teams:
         if team.owner_id in sorted_owner_ids:
             owner_picks[team.owner_id] = team.picks
+        else:
+            logger.warning(
+                "Team owner_id %d not in owners list, skipping from CSV export",
+                team.owner_id,
+            )
 
     max_picks = max(len(picks) for picks in owner_picks.values()) if owner_picks else 0
 
@@ -141,6 +146,7 @@ async def export_draft_csv():
 
 @admin_router.post("/api/v1/nominate")
 async def nominate_player(request: NominateRequest):
+    # Turn order intentionally not enforced -- admin controls nomination sequence.
     """Nominate a player for auction."""
     async with _state_lock:
         # Load current state
@@ -816,6 +822,8 @@ async def reset_draft(request: ResetRequest):
         )
 
         # Save without incrementing version (fresh start at v1)
+        # NB: data/analyst-comments.jsonl is not cleared; its state_version
+        # tags will collide with the new v1+ sequence.
         initial_state.save_to_file(
             _persistence.DRAFT_STATE_FILE, increment_version=False
         )

--- a/src/api/read_routes.py
+++ b/src/api/read_routes.py
@@ -144,6 +144,13 @@ def get_team(owner_id: int):
                     "player": player.model_dump(),
                 }
             )
+        else:
+            logger.warning(
+                "Player %d not found in players.json, skipping from"
+                " team %d roster display",
+                pick.player_id,
+                owner_id,
+            )
 
     return {
         "owner_id": team.owner_id,

--- a/src/booth/slice.py
+++ b/src/booth/slice.py
@@ -46,16 +46,6 @@ RECENT_PICKS_N = 8
 # ---------------------------------------------------------------------------
 # Production scoring (market-derived, no ADP)
 # ---------------------------------------------------------------------------
-def _num(value: str | None) -> float:
-    """Parse a stat string to float; blanks / dashes / junk -> 0.0."""
-    if value is None:
-        return 0.0
-    try:
-        return float(str(value).strip())
-    except ValueError:
-        return 0.0
-
-
 def _has_real_stats(stats: PlayerStats | None) -> bool:
     """True if the player has any prior-season production block recorded."""
     if stats is None:
@@ -77,20 +67,20 @@ def production_score(stats: PlayerStats | None) -> float:
         return 0.0
     score = 0.0
     if stats.passing is not None:
-        score += _num(stats.passing.yards) / 25.0
-        score += _num(stats.passing.tds) * 4.0
-        score -= _num(stats.passing.ints) * 2.0
+        score += stats.passing.yards / 25.0
+        score += stats.passing.tds * 4.0
+        score -= stats.passing.ints * 2.0
     if stats.rushing is not None:
-        score += _num(stats.rushing.yards) / 10.0
-        score += _num(stats.rushing.tds) * 6.0
-        score -= _num(stats.rushing.fumbles) * 2.0
+        score += stats.rushing.yards / 10.0
+        score += stats.rushing.tds * 6.0
+        score -= stats.rushing.fumbles * 2.0
     if stats.receiving is not None:
-        score += _num(stats.receiving.receptions) * 1.0  # PPR
-        score += _num(stats.receiving.yards) / 10.0
-        score += _num(stats.receiving.tds) * 6.0
-        score -= _num(stats.receiving.fumbles) * 2.0
+        score += stats.receiving.receptions * 1.0  # PPR
+        score += stats.receiving.yards / 10.0
+        score += stats.receiving.tds * 6.0
+        score -= stats.receiving.fumbles * 2.0
     if stats.kicking is not None:
-        score += _num(stats.kicking.points)
+        score += stats.kicking.points
     return round(score, 1)
 
 
@@ -116,7 +106,7 @@ class StatLine(BaseModel):
     rookie: bool = False  # no prior-season production -> empty stat line
 
 
-class RosterEntry(BaseModel):
+class RosterLine(BaseModel):
     player_id: int
     name: str
     position: str
@@ -135,7 +125,7 @@ class TeamSnapshot(BaseModel):
     slots_filled: int
     slots_left: int
     position_counts: dict[str, int]
-    roster: list[RosterEntry] = Field(default_factory=list)
+    roster: list[RosterLine] = Field(default_factory=list)
     # Positions still worth chasing, ordered RB>WR>QB>TE>D/ST>K. Threshold-based,
     # not "under position max": RB/WR need to 3 all draft; QB to 1 (2nd late);
     # TE gated on elite-TE availability / roster fill; D/ST & K only when nearly
@@ -380,14 +370,14 @@ def _needs(
     return needs
 
 
-def _roster_entries(team: Team, players: dict[int, Player]) -> list[RosterEntry]:
-    entries: list[RosterEntry] = []
+def _roster_entries(team: Team, players: dict[int, Player]) -> list[RosterLine]:
+    entries: list[RosterLine] = []
     for pick in team.picks:
         player = players.get(pick.player_id)
         if player is None:
             continue
         entries.append(
-            RosterEntry(
+            RosterLine(
                 player_id=player.id,
                 name=player.full_name,
                 position=str(player.position),

--- a/src/models/player_stats.py
+++ b/src/models/player_stats.py
@@ -3,58 +3,105 @@ Player statistics model for fantasy football draft tracker.
 
 This module defines the data models for player statistics including
 2024 season stats and 2025 bye weeks.
+
+Stat fields are typed as ``int`` or ``float`` with ``BeforeValidator``
+coercion so that raw JSON strings (including blanks, dashes, and
+comma-separated numbers scraped from ESPN) are converted automatically.
 """
 
-from pydantic import BaseModel, Field, RootModel
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import BaseModel, BeforeValidator, Field, RootModel
+
+
+def _coerce_int(v: object) -> int:
+    """Coerce a stat value to ``int``; blanks / dashes / junk -> 0."""
+    if isinstance(v, int):
+        return v
+    if isinstance(v, float):
+        return int(v)
+    if not isinstance(v, str):
+        return 0
+    v = v.strip().replace(",", "")
+    if not v or v == "-":
+        return 0
+    try:
+        return int(v)
+    except ValueError:
+        try:
+            return int(float(v))
+        except ValueError:
+            return 0
+
+
+def _coerce_float(v: object) -> float:
+    """Coerce a stat value to ``float``; blanks / dashes / junk -> 0.0."""
+    if isinstance(v, (int, float)):
+        return float(v)
+    if not isinstance(v, str):
+        return 0.0
+    v = v.strip().replace(",", "")
+    if not v or v == "-":
+        return 0.0
+    try:
+        return float(v)
+    except ValueError:
+        return 0.0
+
+
+StatInt = Annotated[int, BeforeValidator(_coerce_int)]
+StatFloat = Annotated[float, BeforeValidator(_coerce_float)]
 
 
 class PassingStats(BaseModel):
     """Passing statistics for quarterbacks."""
 
-    completions: str = Field(..., description="Number of completions")
-    attempts: str = Field(..., description="Number of passing attempts")
-    pct: str = Field(..., description="Completion percentage")
-    yards: str = Field(..., description="Passing yards")
-    avg: str = Field(..., description="Yards per attempt")
-    tds: str = Field(..., description="Passing touchdowns")
-    ints: str = Field(..., description="Interceptions thrown")
-    sacks: str = Field(..., description="Times sacked")
-    rating: str = Field(..., description="Passer rating")
+    completions: StatInt = Field(..., description="Number of completions")
+    attempts: StatInt = Field(..., description="Number of passing attempts")
+    pct: StatFloat = Field(..., description="Completion percentage")
+    yards: StatInt = Field(..., description="Passing yards")
+    avg: StatFloat = Field(..., description="Yards per attempt")
+    tds: StatInt = Field(..., description="Passing touchdowns")
+    ints: StatInt = Field(..., description="Interceptions thrown")
+    sacks: StatInt = Field(..., description="Times sacked")
+    rating: StatFloat = Field(..., description="Passer rating")
 
 
 class RushingStats(BaseModel):
     """Rushing statistics for running backs, wide receivers, and quarterbacks."""
 
-    carries: str = Field(..., description="Number of rushing attempts")
-    yards: str = Field(..., description="Rushing yards")
-    avg: str = Field(..., description="Yards per carry")
-    tds: str = Field(..., description="Rushing touchdowns")
-    long: str = Field(..., description="Longest rush")
-    fumbles: str = Field(..., description="Fumbles")
+    carries: StatInt = Field(..., description="Number of rushing attempts")
+    yards: StatInt = Field(..., description="Rushing yards")
+    avg: StatFloat = Field(..., description="Yards per carry")
+    tds: StatInt = Field(..., description="Rushing touchdowns")
+    long: StatInt = Field(..., description="Longest rush")
+    fumbles: StatInt = Field(..., description="Fumbles")
 
 
 class ReceivingStats(BaseModel):
     """Receiving statistics for wide receivers, tight ends, and running backs."""
 
-    receptions: str = Field(..., description="Number of receptions")
-    targets: str = Field(..., description="Number of targets")
-    yards: str = Field(..., description="Receiving yards")
-    avg: str = Field(..., description="Yards per reception")
-    tds: str = Field(..., description="Receiving touchdowns")
-    long: str = Field(..., description="Longest reception")
-    fumbles: str = Field(..., description="Fumbles")
+    receptions: StatInt = Field(..., description="Number of receptions")
+    targets: StatInt = Field(..., description="Number of targets")
+    yards: StatInt = Field(..., description="Receiving yards")
+    avg: StatFloat = Field(..., description="Yards per reception")
+    tds: StatInt = Field(..., description="Receiving touchdowns")
+    long: StatInt = Field(..., description="Longest reception")
+    fumbles: StatInt = Field(..., description="Fumbles")
 
 
 class KickingStats(BaseModel):
     """Kicking statistics for kickers."""
 
-    fgm: str = Field(..., description="Field goals made")
-    fga: str = Field(..., description="Field goals attempted")
-    fg_pct: str = Field(..., description="Field goal percentage")
-    long: str = Field(..., description="Longest field goal")
-    xpm: str = Field(..., description="Extra points made")
-    xpa: str = Field(..., description="Extra points attempted")
-    points: str = Field(..., description="Total points scored")
+    fgm: StatInt = Field(..., description="Field goals made")
+    fga: StatInt = Field(..., description="Field goals attempted")
+    fg_pct: StatFloat = Field(..., description="Field goal percentage")
+    long: StatInt = Field(..., description="Longest field goal")
+    xpm: StatInt = Field(..., description="Extra points made")
+    xpa: StatInt = Field(..., description="Extra points attempted")
+    points: StatInt = Field(..., description="Total points scored")
 
 
 class PlayerStats(BaseModel):

--- a/tests/unit/models/test_player_stats.py
+++ b/tests/unit/models/test_player_stats.py
@@ -1,0 +1,242 @@
+"""Unit tests for PlayerStats model and stat-field coercion.
+
+Covers the ``BeforeValidator`` coercion on ``StatInt`` and ``StatFloat``
+annotated types: normal strings, comma-separated numbers, dashes, blank
+strings, and already-numeric values.
+"""
+
+from src.models.player_stats import (
+    KickingStats,
+    PassingStats,
+    PlayerStats,
+    PlayerStatsCollection,
+    ReceivingStats,
+    RushingStats,
+    _coerce_float,
+    _coerce_int,
+)
+
+
+# ---------------------------------------------------------------------------
+# Low-level coercion helpers
+# ---------------------------------------------------------------------------
+class TestCoerceInt:
+    def test_normal_string(self):
+        assert _coerce_int("400") == 400
+
+    def test_comma_separated(self):
+        assert _coerce_int("1,071") == 1071
+
+    def test_dash(self):
+        assert _coerce_int("-") == 0
+
+    def test_blank(self):
+        assert _coerce_int("") == 0
+
+    def test_whitespace(self):
+        assert _coerce_int("  ") == 0
+
+    def test_already_int(self):
+        assert _coerce_int(42) == 42
+
+    def test_float_input(self):
+        assert _coerce_int(4.9) == 4
+
+    def test_junk(self):
+        assert _coerce_int("N/A") == 0
+
+    def test_none_like(self):
+        assert _coerce_int(None) == 0
+
+
+class TestCoerceFloat:
+    def test_normal_string(self):
+        assert _coerce_float("66.7") == 66.7
+
+    def test_integer_string(self):
+        assert _coerce_float("150") == 150.0
+
+    def test_comma_separated(self):
+        assert _coerce_float("1,500") == 1500.0
+
+    def test_dash(self):
+        assert _coerce_float("-") == 0.0
+
+    def test_blank(self):
+        assert _coerce_float("") == 0.0
+
+    def test_already_float(self):
+        assert _coerce_float(8.3) == 8.3
+
+    def test_already_int(self):
+        assert _coerce_float(8) == 8.0
+
+    def test_junk(self):
+        assert _coerce_float("N/A") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Stat sub-models accept string values and coerce to numeric
+# ---------------------------------------------------------------------------
+class TestPassingStatsCoercion:
+    def test_from_string_values(self):
+        stats = PassingStats(
+            completions="400",
+            attempts="600",
+            pct="66.7",
+            yards="5,000",
+            avg="8.3",
+            tds="40",
+            ints="10",
+            sacks="20",
+            rating="110.0",
+        )
+        assert stats.completions == 400
+        assert stats.yards == 5000
+        assert stats.pct == 66.7
+        assert stats.rating == 110.0
+
+    def test_dash_values(self):
+        stats = PassingStats(
+            completions="-",
+            attempts="-",
+            pct="-",
+            yards="-",
+            avg="-",
+            tds="-",
+            ints="-",
+            sacks="-",
+            rating="-",
+        )
+        assert stats.completions == 0
+        assert stats.yards == 0
+        assert stats.pct == 0.0
+
+
+class TestRushingStatsCoercion:
+    def test_from_string_values(self):
+        stats = RushingStats(
+            carries="203",
+            yards="1,431",
+            avg="4.5",
+            tds="6",
+            long="61",
+            fumbles="0",
+        )
+        assert stats.carries == 203
+        assert stats.yards == 1431
+        assert stats.avg == 4.5
+
+    def test_all_dashes(self):
+        stats = RushingStats(
+            carries="-",
+            yards="-",
+            avg="-",
+            tds="-",
+            long="-",
+            fumbles="-",
+        )
+        assert stats.carries == 0
+        assert stats.yards == 0
+        assert stats.avg == 0.0
+
+
+class TestReceivingStatsCoercion:
+    def test_from_string_values(self):
+        stats = ReceivingStats(
+            receptions="78",
+            targets="87",
+            yards="1,708",
+            avg="7.6",
+            tds="6",
+            long="39",
+            fumbles="1",
+        )
+        assert stats.receptions == 78
+        assert stats.yards == 1708
+        assert stats.avg == 7.6
+
+
+class TestKickingStatsCoercion:
+    def test_from_string_values(self):
+        stats = KickingStats(
+            fgm="35",
+            fga="40",
+            fg_pct="87.5",
+            long="58",
+            xpm="45",
+            xpa="45",
+            points="150",
+        )
+        assert stats.fgm == 35
+        assert stats.fg_pct == 87.5
+        assert stats.points == 150
+
+
+# ---------------------------------------------------------------------------
+# Full PlayerStats round-trip
+# ---------------------------------------------------------------------------
+class TestPlayerStatsRoundTrip:
+    def test_validate_from_json_strings(self):
+        """Mirrors the shape of data/player_stats.json entries."""
+        raw = {
+            "bye_week": 12,
+            "position": "RB",
+            "team": "MIA",
+            "rushing": {
+                "carries": "203",
+                "yards": "907",
+                "avg": "4.5",
+                "tds": "6",
+                "long": "61",
+                "fumbles": "0",
+            },
+            "receiving": {
+                "receptions": "78",
+                "targets": "87",
+                "yards": "592",
+                "avg": "7.6",
+                "tds": "6",
+                "long": "39",
+                "fumbles": "1",
+            },
+            "stats_summary": "Rush: 203att 907yds 6TD | Rec: 78rec 592yds 6TD",
+        }
+        ps = PlayerStats.model_validate(raw)
+        assert ps.rushing.yards == 907
+        assert ps.receiving.receptions == 78
+        assert ps.stats_summary is not None
+
+    def test_no_stat_blocks(self):
+        raw = {"bye_week": 5, "position": "RB", "team": "GB"}
+        ps = PlayerStats.model_validate(raw)
+        assert ps.passing is None
+        assert ps.rushing is None
+        assert ps.stats_summary is None
+
+
+class TestPlayerStatsCollection:
+    def test_get_player_stats(self):
+        raw = {
+            "123": {
+                "bye_week": 6,
+                "position": "QB",
+                "team": "KC",
+                "passing": {
+                    "completions": "10",
+                    "attempts": "20",
+                    "pct": "50.0",
+                    "yards": "100",
+                    "avg": "5.0",
+                    "tds": "1",
+                    "ints": "0",
+                    "sacks": "2",
+                    "rating": "80.0",
+                },
+            }
+        }
+        coll = PlayerStatsCollection.model_validate(raw)
+        ps = coll.get_player_stats(123)
+        assert ps is not None
+        assert ps.passing.completions == 10
+        assert coll.get_player_stats(999) is None

--- a/tests/unit/test_player_stats_endpoint.py
+++ b/tests/unit/test_player_stats_endpoint.py
@@ -83,7 +83,7 @@ class TestPlayerStatsEndpoint:
             assert rb_stats["bye_week"] == 5
             assert rb_stats["position"] == "RB"
             assert rb_stats["team"] == "GB"
-            assert rb_stats["rushing"]["carries"] == "66"
+            assert rb_stats["rushing"]["carries"] == 66
             assert rb_stats["stats_summary"] == "Rush: 66att 311yds 2TD"
 
             # Check QB stats
@@ -91,7 +91,7 @@ class TestPlayerStatsEndpoint:
             assert qb_stats["bye_week"] == 7
             assert qb_stats["position"] == "QB"
             assert qb_stats["team"] == "BUF"
-            assert qb_stats["passing"]["completions"] == "359"
+            assert qb_stats["passing"]["completions"] == 359
             assert qb_stats["stats_summary"] == "359/541 4306yds 29TD 18INT"
 
         finally:


### PR DESCRIPTION
## Summary
Final cleanup sweep from the backend review (R6 + R7 + C2):

**R6 — PlayerStats numeric types:**
- All stat fields changed from `str` to `int`/`float` with Pydantic `BeforeValidator` coercion (handles commas, dashes, blanks from the raw data)
- Deleted the `_num()` parsing helper from `src/booth/slice.py` — callers use numeric fields directly
- New unit tests for coercion edge cases

**R7 — Small fixes:**
- Renamed booth-internal `RosterEntry` to `RosterLine` to avoid collision with `league_history.py`'s `RosterEntry`
- Added `logger.warning` for silent data drops (missing player in team display, missing owner in CSV export)
- Added comment in `reset_draft` noting commentary log is not cleared (version tags will collide)
- Added comment in `nominate_player` documenting that turn order is intentionally not enforced

**C2 — CORS cleanup:**
- Dropped invalid `allow_credentials=True` (nothing uses cookies/auth)
- Restricted `allow_methods` and `allow_headers` to what's actually used
- Viewer app limited to `GET`/`OPTIONS` only

## Test plan
- [x] 346 tests pass (26 new from PlayerStats coercion + endpoint tests)
- [x] Ruff lint + format clean
- [x] Verified no cross-port fetch calls in templates/static (CORS simplification is safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)