### PR TITLE
refactor: extract shared JS, add HTML escaping, fix WAS logo (F2, F3, R1)

### DIFF
--- a/static/js/draft-shared.js
+++ b/static/js/draft-shared.js
@@ -1,0 +1,134 @@
+/* draft-shared.js — code shared by the admin console (index.html) and the
+   read-only team viewer (team_viewer.html).
+
+   Loaded as a classic script before each template's inline <script>, so every
+   declaration below is a plain global. Nothing here may be re-declared inline:
+   a top-level `const` in one script and another in a second script share the
+   global lexical environment and collide with a SyntaxError.
+
+   These constructs used to be copy-pasted into both templates and had already
+   drifted apart (Washington's logo slug, the team-color fallback, budgetClass's
+   signature). One copy, one behavior. */
+
+/* ── HTML escaping ────────────────────────────────────────────────────────
+   Every owner/team/player name that reaches innerHTML or an interpolated
+   attribute goes through esc(). Names are free text: a `"` or `<` in one
+   ("D'Amato \"The Hammer\"") otherwise corrupts the surrounding markup.
+
+   Numbers, IDs, position enums, and CSS color values are safe by construction
+   and are left alone. Booth comment text uses createElement/textContent and
+   never needs this. */
+function esc(s) {
+    return String(s ?? '').replace(/[&<>"']/g,
+        c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+/* ── NFL team logos (ESPN CDN) ────────────────────────────────────────────
+   Washington's slug is `wsh`, not `was` — the admin console had `was.png`
+   (404) while the viewer had it right. The unknown-team fallback is the
+   generic shield rather than an interpolated abbreviation, so nothing
+   attacker-shaped can be spliced into an <img src>. */
+const NFL_TEAM_LOGOS = {
+    'ARI': 'https://a.espncdn.com/i/teamlogos/nfl/500/ari.png',
+    'ATL': 'https://a.espncdn.com/i/teamlogos/nfl/500/atl.png',
+    'BAL': 'https://a.espncdn.com/i/teamlogos/nfl/500/bal.png',
+    'BUF': 'https://a.espncdn.com/i/teamlogos/nfl/500/buf.png',
+    'CAR': 'https://a.espncdn.com/i/teamlogos/nfl/500/car.png',
+    'CHI': 'https://a.espncdn.com/i/teamlogos/nfl/500/chi.png',
+    'CIN': 'https://a.espncdn.com/i/teamlogos/nfl/500/cin.png',
+    'CLE': 'https://a.espncdn.com/i/teamlogos/nfl/500/cle.png',
+    'DAL': 'https://a.espncdn.com/i/teamlogos/nfl/500/dal.png',
+    'DEN': 'https://a.espncdn.com/i/teamlogos/nfl/500/den.png',
+    'DET': 'https://a.espncdn.com/i/teamlogos/nfl/500/det.png',
+    'GB': 'https://a.espncdn.com/i/teamlogos/nfl/500/gb.png',
+    'HOU': 'https://a.espncdn.com/i/teamlogos/nfl/500/hou.png',
+    'IND': 'https://a.espncdn.com/i/teamlogos/nfl/500/ind.png',
+    'JAX': 'https://a.espncdn.com/i/teamlogos/nfl/500/jax.png',
+    'KC': 'https://a.espncdn.com/i/teamlogos/nfl/500/kc.png',
+    'LV': 'https://a.espncdn.com/i/teamlogos/nfl/500/lv.png',
+    'LAC': 'https://a.espncdn.com/i/teamlogos/nfl/500/lac.png',
+    'LAR': 'https://a.espncdn.com/i/teamlogos/nfl/500/lar.png',
+    'MIA': 'https://a.espncdn.com/i/teamlogos/nfl/500/mia.png',
+    'MIN': 'https://a.espncdn.com/i/teamlogos/nfl/500/min.png',
+    'NE': 'https://a.espncdn.com/i/teamlogos/nfl/500/ne.png',
+    'NO': 'https://a.espncdn.com/i/teamlogos/nfl/500/no.png',
+    'NYG': 'https://a.espncdn.com/i/teamlogos/nfl/500/nyg.png',
+    'NYJ': 'https://a.espncdn.com/i/teamlogos/nfl/500/nyj.png',
+    'PHI': 'https://a.espncdn.com/i/teamlogos/nfl/500/phi.png',
+    'PIT': 'https://a.espncdn.com/i/teamlogos/nfl/500/pit.png',
+    'SEA': 'https://a.espncdn.com/i/teamlogos/nfl/500/sea.png',
+    'SF': 'https://a.espncdn.com/i/teamlogos/nfl/500/sf.png',
+    'TB': 'https://a.espncdn.com/i/teamlogos/nfl/500/tb.png',
+    'TEN': 'https://a.espncdn.com/i/teamlogos/nfl/500/ten.png',
+    'WAS': 'https://a.espncdn.com/i/teamlogos/nfl/500/wsh.png'
+};
+function getTeamLogoUrl(teamAbbr) {
+    return NFL_TEAM_LOGOS[teamAbbr] || 'https://a.espncdn.com/i/teamlogos/nfl/500/nfl.png';
+}
+
+/* ── Per-team signature colors ────────────────────────────────────────────
+   Each team's brand color, shifted brighter where the primary is too dark to
+   read on the steel/dark backgrounds. Used for the auction backdrop tint
+   (admin) and subtle card tints (viewer).
+
+   Exposed two ways because the templates reach for it differently: the map
+   directly, or the accessor with its gold fallback. Every caller passes a
+   validated NFLTeam enum value, so the fallback is belt-and-braces. */
+const NFL_COLORS = {
+    ARI: '#C8102E', ATL: '#E31837', BAL: '#5E48A8', BUF: '#1A6DD6', CAR: '#0085CA', CHI: '#E0541C',
+    CIN: '#FB4F14', CLE: '#FF6A2B', DAL: '#2A5BD0', DEN: '#FB4F14', DET: '#1B8FD6', GB: '#3A8C52',
+    HOU: '#C8324B', IND: '#2A74C4', JAX: '#13909E', KC: '#E31837', LV: '#B9C0C4', LAC: '#0FA0E0',
+    LAR: '#2A63E0', MIA: '#00B6C0', MIN: '#6A3CB0', NE: '#D33C50', NO: '#D3BC8D', NYG: '#2A52C9',
+    NYJ: '#2E8C5E', PHI: '#1A8579', PIT: '#FFB612', SEA: '#69BE28', SF: '#C8102E', TB: '#D50A0A',
+    TEN: '#4B92DB', WAS: '#9A3550'
+};
+function teamColor(teamAbbr) {
+    return NFL_COLORS[teamAbbr] || '#E8A33D';
+}
+
+/* ── ESPN player headshot ─────────────────────────────────────────────────
+   D/ST has no headshot; callers substitute the team logo. */
+function headshotUrl(playerId) {
+    return `https://a.espncdn.com/combiner/i?img=/i/headshots/nfl/players/full/${playerId}.png&w=350&h=254`;
+}
+
+/* ── Analyst booth personas ───────────────────────────────────────────────
+   Accent ring + headshot file, with an initials monogram for unknowns. */
+const BOOTH_PERSONAS = {
+    eisen: { accent: '#E8A33D', slug: 'eisen', name: 'Rich Eisen' },
+    kiper: { accent: '#56C5D0', slug: 'kiper', name: 'Mel Kiper Jr.' },
+    schefter: { accent: '#E2574C', slug: 'schefter', name: 'Adam Schefter' },
+    booger: { accent: '#5BBF7B', slug: 'booger', name: 'Booger McFarland' },
+    kimes: { accent: '#9B8CEF', slug: 'kimes', name: 'Mina Kimes' },
+    mcafee: { accent: '#F0913E', slug: 'mcafee', name: 'Pat McAfee' },
+};
+const BOOTH_LINEUP = ['eisen', 'kiper', 'schefter', 'booger', 'kimes', 'mcafee'];
+function boothPersona(name) {
+    const key = (name || '').toLowerCase().replace(/[^a-z]/g, '');
+    const m = BOOTH_PERSONAS[key];
+    const label = (name || '?').toUpperCase();
+    const initials = (name || '?').replace(/[^A-Za-z]/g, '').slice(0, 2).toUpperCase() || '?';
+    return m
+        ? { key, label, fullName: m.name, accent: m.accent, img: `/static/img/personas/${m.slug}.jpg`, initials }
+        : { key, label, fullName: (name || ''), accent: 'var(--slate)', img: '', initials };  // unknown -> monogram
+}
+
+/* ── Budget health class ──────────────────────────────────────────────────
+   Takes the raw remaining/initial dollars rather than a team object, since
+   the two templates model a team differently. */
+function budgetClass(remaining, initialBudget) {
+    const pct = (remaining / initialBudget) * 100;
+    if (pct <= 15) return 'crit';
+    if (pct <= 35) return 'warn';
+    return 'ok';
+}
+
+/* ── FOUT guard ───────────────────────────────────────────────────────────
+   Both layouts size themselves off webfont metrics, so the page stays hidden
+   until the fonts land — with a timeout so a font CDN outage can't strand it. */
+function revealOnReady(el, delayMs = 1500) {
+    if (!el) return;
+    const reveal = () => el.classList.add('ready');
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(reveal);
+    setTimeout(reveal, delayMs);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,7 +55,8 @@
                src=""
                alt=""
                width="500"
-               height="500">
+               height="500"
+               onerror="this.style.display='none'">
           <div class="hero-eyebrow">
             <span class="auctioning">Now Auctioning</span>
             <span class="live"><span class="dot"></span>LIVE</span>
@@ -228,6 +229,7 @@
         </div>
       </div>
     </aside>
+    <script src="/static/js/draft-shared.js?v=1"></script>
     <script>
         // Server-injected (change F): config is authoritative; no hardcoded fallbacks.
         let config = {{ config | tojson }};
@@ -259,59 +261,10 @@
         }
         document.addEventListener('keydown', e => { if (e.key === 'Escape') closeDrawer(); });
 
-        function getTeamLogoUrl(teamAbbr) {
-            const teamMappings = {
-                'ARI': 'https://a.espncdn.com/i/teamlogos/nfl/500/ari.png',
-                'ATL': 'https://a.espncdn.com/i/teamlogos/nfl/500/atl.png',
-                'BAL': 'https://a.espncdn.com/i/teamlogos/nfl/500/bal.png',
-                'BUF': 'https://a.espncdn.com/i/teamlogos/nfl/500/buf.png',
-                'CAR': 'https://a.espncdn.com/i/teamlogos/nfl/500/car.png',
-                'CHI': 'https://a.espncdn.com/i/teamlogos/nfl/500/chi.png',
-                'CIN': 'https://a.espncdn.com/i/teamlogos/nfl/500/cin.png',
-                'CLE': 'https://a.espncdn.com/i/teamlogos/nfl/500/cle.png',
-                'DAL': 'https://a.espncdn.com/i/teamlogos/nfl/500/dal.png',
-                'DEN': 'https://a.espncdn.com/i/teamlogos/nfl/500/den.png',
-                'DET': 'https://a.espncdn.com/i/teamlogos/nfl/500/det.png',
-                'GB': 'https://a.espncdn.com/i/teamlogos/nfl/500/gb.png',
-                'HOU': 'https://a.espncdn.com/i/teamlogos/nfl/500/hou.png',
-                'IND': 'https://a.espncdn.com/i/teamlogos/nfl/500/ind.png',
-                'JAX': 'https://a.espncdn.com/i/teamlogos/nfl/500/jax.png',
-                'KC': 'https://a.espncdn.com/i/teamlogos/nfl/500/kc.png',
-                'LV': 'https://a.espncdn.com/i/teamlogos/nfl/500/lv.png',
-                'LAC': 'https://a.espncdn.com/i/teamlogos/nfl/500/lac.png',
-                'LAR': 'https://a.espncdn.com/i/teamlogos/nfl/500/lar.png',
-                'MIA': 'https://a.espncdn.com/i/teamlogos/nfl/500/mia.png',
-                'MIN': 'https://a.espncdn.com/i/teamlogos/nfl/500/min.png',
-                'NE': 'https://a.espncdn.com/i/teamlogos/nfl/500/ne.png',
-                'NO': 'https://a.espncdn.com/i/teamlogos/nfl/500/no.png',
-                'NYG': 'https://a.espncdn.com/i/teamlogos/nfl/500/nyg.png',
-                'NYJ': 'https://a.espncdn.com/i/teamlogos/nfl/500/nyj.png',
-                'PHI': 'https://a.espncdn.com/i/teamlogos/nfl/500/phi.png',
-                'PIT': 'https://a.espncdn.com/i/teamlogos/nfl/500/pit.png',
-                'SEA': 'https://a.espncdn.com/i/teamlogos/nfl/500/sea.png',
-                'SF': 'https://a.espncdn.com/i/teamlogos/nfl/500/sf.png',
-                'TB': 'https://a.espncdn.com/i/teamlogos/nfl/500/tb.png',
-                'TEN': 'https://a.espncdn.com/i/teamlogos/nfl/500/ten.png',
-                'WAS': 'https://a.espncdn.com/i/teamlogos/nfl/500/was.png'
-            };
-            return teamMappings[teamAbbr] || 'https://a.espncdn.com/i/teamlogos/nfl/500/nfl.png';
-        }
+        // esc(), getTeamLogoUrl(), teamColor(), headshotUrl(), budgetClass(),
+        // BOOTH_PERSONAS/boothPersona(), revealOnReady() all come from
+        // /static/js/draft-shared.js (loaded above) — shared with the team viewer.
 
-        // Hardcoded per-team tint for the auction backdrop — each team's signature color,
-        // shifted brighter where the brand primary is too dark to read on the steel bg.
-        function getTeamColor(teamAbbr) {
-            const colors = {
-                'ARI': '#C8102E', 'ATL': '#E31837', 'BAL': '#5E48A8', 'BUF': '#1A6DD6',
-                'CAR': '#0085CA', 'CHI': '#E0541C', 'CIN': '#FB4F14', 'CLE': '#FF6A2B',
-                'DAL': '#2A5BD0', 'DEN': '#FB4F14', 'DET': '#1B8FD6', 'GB': '#3A8C52',
-                'HOU': '#C8324B', 'IND': '#2A74C4', 'JAX': '#13909E', 'KC': '#E31837',
-                'LV': '#B9C0C4', 'LAC': '#0FA0E0', 'LAR': '#2A63E0', 'MIA': '#00B6C0',
-                'MIN': '#6A3CB0', 'NE': '#D33C50', 'NO': '#D3BC8D', 'NYG': '#2A52C9',
-                'NYJ': '#2E8C5E', 'PHI': '#1A8579', 'PIT': '#FFB612', 'SEA': '#69BE28',
-                'SF': '#C8102E', 'TB': '#D50A0A', 'TEN': '#4B92DB', 'WAS': '#9A3550'
-            };
-            return colors[teamAbbr] || '#E8A33D';
-        }
         async function loadData() {
             try {
                 players = await (await fetch('/api/v1/players')).json();
@@ -385,7 +338,7 @@
             if (position === 'RB' && s.rushing) return ` · ${s.rushing.yards} yds · ${s.rushing.tds} TD`;
             if ((position === 'WR' || position === 'TE') && s.receiving) return ` · ${s.receiving.yards} yds · ${s.receiving.tds} TD`;
             if (position === 'K' && s.kicking) return ` · ${s.kicking.points} pts`;
-            return s.stats_summary ? ` · ${s.stats_summary}` : '';
+            return s.stats_summary ? ` · ${esc(s.stats_summary)}` : '';   // free text -> escaped
         }
 
         // Bye week for the nominee. D/ST has no per-player stats row, so derive it from
@@ -410,24 +363,25 @@
                 if (player) {
                     const logo = getTeamLogoUrl(player.team);
                     const heroActive = document.querySelector('.hero.active');
-                    if (heroActive) heroActive.style.setProperty('--team-tint', getTeamColor(player.team));
-                    const img = player.position === 'D/ST'
-                        ? logo
-                        : `https://a.espncdn.com/combiner/i?img=/i/headshots/nfl/players/full/${player.id}.png&w=350&h=254`;
+                    if (heroActive) heroActive.style.setProperty('--team-tint', teamColor(player.team));
+                    const img = player.position === 'D/ST' ? logo : headshotUrl(player.id);
                     const name = player.position === 'D/ST'
                         ? `${player.first_name} ${player.last_name}`
                         : `${player.last_name}, ${player.first_name}`;
                     document.getElementById('hero-posbadge').textContent = player.position;
                     const photo = document.getElementById('hero-photo-img');
                     photo.style.display = ''; photo.src = img; photo.alt = player.last_name; photo.onerror = function(){ this.style.display='none'; };
-                    document.getElementById('hero-logo').src = logo;
+                    // Un-hide first: the inline onerror hides the logo on a 404, and the
+                    // element is reused for every nominee.
+                    const logoEl = document.getElementById('hero-logo');
+                    logoEl.style.display = ''; logoEl.src = logo;
                     document.getElementById('hero-name').textContent = name;
                     const bye = playerByeWeek(player);
                     const byeEl = document.getElementById('hero-bye');
                     if (bye) document.getElementById('hero-bye-num').textContent = bye;
                     byeEl.classList.toggle('is-hidden', !bye);
                     document.getElementById('hero-meta').innerHTML =
-                        `${player.position} · <b>${player.team}</b>${heroStatLine(player.id, player.position)}`;
+                        `${esc(player.position)} · <b>${esc(player.team)}</b>${heroStatLine(player.id, player.position)}`;
                     document.getElementById('bid-amt').textContent = `$${nominated.current_bid}`;
                     document.getElementById('bidder-chip').style.background = bidder ? bidder.color : '#8A9BB5';
                     document.getElementById('bidder-nm').textContent = bidder ? bidder.team_name : 'Unknown';
@@ -446,7 +400,7 @@
             nameEl.textContent = team ? team.team_name : '—';
             nameEl.style.color = color;
             document.getElementById('standby-meta').innerHTML =
-                `${team ? team.owner_name : ''} · <b>awaiting nomination</b>`;
+                `${team ? esc(team.owner_name) : ''} · <b>awaiting nomination</b>`;
             const sil = document.getElementById('standby-sil');
             sil.querySelectorAll('[fill]').forEach(node => node.setAttribute('fill', color));
         }
@@ -455,8 +409,8 @@
             const onClock = owners.find(o => o.id === draftState.next_to_nominate);
             const upNext = draftState.up_next ? owners.find(o => o.id === draftState.up_next) : null;
             let html = '';
-            if (onClock) html = `On the clock: <b>${onClock.team_name}</b>`;
-            if (upNext) html += ` · Up Next <b>${upNext.team_name}</b>`;
+            if (onClock) html = `On the clock: <b>${esc(onClock.team_name)}</b>`;
+            if (upNext) html += ` · Up Next <b>${esc(upNext.team_name)}</b>`;
             document.getElementById('ondeck').innerHTML = html;
         }
 
@@ -470,7 +424,7 @@
                 t.picks.forEach(pk => {
                     const p = players.find(pl => pl.id === pk.player_id);
                     if (p) picks.push({ id: pk.pick_id,
-                        html: `<b>${p.first_name} ${p.last_name}</b> (${p.position}) → ${o ? o.team_name : '?'} <span class="amt">$${pk.price}</span>` });
+                        html: `<b>${esc(p.first_name)} ${esc(p.last_name)}</b> (${p.position}) → ${o ? esc(o.team_name) : '?'} <span class="amt">$${pk.price}</span>` });
                 });
             });
             picks.sort((a, b) => b.id - a.id);
@@ -490,24 +444,7 @@
         }
 
         // ---- Analyst booth chyron (live commentary from /api/v1/comments) ----
-        // Per-persona identity: accent ring + headshot file (or initials fallback).
-        const BOOTH_PERSONAS = {
-            eisen:    { accent: '#E8A33D', slug: 'eisen',    name: 'Rich Eisen' },
-            kiper:    { accent: '#56C5D0', slug: 'kiper',    name: 'Mel Kiper Jr.' },
-            schefter: { accent: '#E2574C', slug: 'schefter', name: 'Adam Schefter' },
-            booger:   { accent: '#5BBF7B', slug: 'booger',   name: 'Booger McFarland' },
-            kimes:    { accent: '#9B8CEF', slug: 'kimes',    name: 'Mina Kimes' },
-            mcafee:   { accent: '#F0913E', slug: 'mcafee',   name: 'Pat McAfee' },
-        };
-        function boothPersona(name) {
-            const key = (name || '').toLowerCase().replace(/[^a-z]/g, '');
-            const m = BOOTH_PERSONAS[key];
-            const label = (name || '?').toUpperCase();
-            const initials = (name || '?').replace(/[^A-Za-z]/g, '').slice(0, 2).toUpperCase() || '?';
-            return m
-                ? { label, fullName: m.name, accent: m.accent, img: `/static/img/personas/${m.slug}.jpg`, initials }
-                : { label, fullName: (name || ''), accent: 'var(--slate)', img: '', initials };  // unknown -> monogram
-        }
+        // Persona identity (BOOTH_PERSONAS / boothPersona) lives in draft-shared.js.
         let boothBuffer = [];        // recent comments, ascending seq
         let boothLastSeq = 0;        // watermark
         let boothExpanded = false;
@@ -614,7 +551,7 @@
                 const option = document.createElement('div');
                 option.className = 'player-option';
                 option.dataset.playerId = player.id;
-                option.innerHTML = `<strong>${player.first_name} ${player.last_name}</strong> - ${player.position} (${player.team})`;
+                option.innerHTML = `<strong>${esc(player.first_name)} ${esc(player.last_name)}</strong> - ${esc(player.position)} (${esc(player.team)})`;
                 option.onclick = () => selectPlayerFromDropdown(player);
                 dropdown.appendChild(option);
             });
@@ -709,13 +646,6 @@
             const p = players.find(pl => pl.id === draftState.nominated.player_id);
             return p ? p.position : null;
         }
-        function budgetClass(team) {
-            const pct = (team.budget_remaining / config.initial_budget) * 100;
-            if (pct <= 15) return 'crit';
-            if (pct <= 35) return 'warn';
-            return 'ok';
-        }
-
         // Can this team legally bid `amount` on the current nominee? (parity with
         // backend + updateBidButtonState): not done, within budget, within roster-safe
         // max bid, and not already at the position maximum for the nominee.
@@ -786,7 +716,7 @@
 
                 const pct = Math.round(team.picks.length / total * 100);
                 const budgetPct = Math.round(team.budget_remaining / config.initial_budget * 100);
-                const bcls = budgetClass(team);
+                const bcls = budgetClass(team.budget_remaining, config.initial_budget);
                 const maxBid = team.max_bid;  // server: int | null
                 const maxEl = (maxBid === null || maxBid === undefined)
                     ? '<span class="v max">—</span>'
@@ -818,8 +748,8 @@
                             ${statusEl}
                             ${hk ? `<span class="hotkey" title="Press ${hk} to select this team">${hk}</span>` : ''}
                         </div>
-                        <span class="tname">${owner ? owner.team_name : 'Unknown Team'}</span>
-                        <span class="owner">${owner ? owner.owner_name : 'Unknown'}</span>
+                        <span class="tname">${owner ? esc(owner.team_name) : 'Unknown Team'}</span>
+                        <span class="owner">${owner ? esc(owner.owner_name) : 'Unknown'}</span>
                         <span class="spacer"></span>
                         <div class="stat-row">
                             <div class="stat"><span class="k">Budget</span><span class="v money ${bcls} tnum">$${team.budget_remaining}</span></div>
@@ -1216,14 +1146,14 @@
             doneSel.innerHTML = '<option value="">Select team…</option>';
             teams.forEach(t => {
                 const o = owners.find(ow => ow.id === t.owner_id);
-                if (o && !t.manually_done) doneSel.insertAdjacentHTML('beforeend', `<option value="${t.owner_id}">${o.team_name}</option>`);
+                if (o && !t.manually_done) doneSel.insertAdjacentHTML('beforeend', `<option value="${t.owner_id}">${esc(o.team_name)}</option>`);
             });
             // Transfer target: all teams
             const transferSel = document.getElementById('transfer-select');
             transferSel.innerHTML = '<option value="">Transfer to…</option>';
             teams.forEach(t => {
                 const o = owners.find(ow => ow.id === t.owner_id);
-                if (o) transferSel.insertAdjacentHTML('beforeend', `<option value="${t.owner_id}">${o.team_name}</option>`);
+                if (o) transferSel.insertAdjacentHTML('beforeend', `<option value="${t.owner_id}">${esc(o.team_name)}</option>`);
             });
             // Remove/Transfer source: every drafted pick, sorted by last name
             const removeSel = document.getElementById('remove-select');
@@ -1237,9 +1167,9 @@
                         label: `${p.last_name}, ${p.first_name} · ${o ? o.team_name : '?'} ($${pk.price})` });
                 });
             });
-            picks.sort((a, b) => a.label.localeCompare(b.label));
+            picks.sort((a, b) => a.label.localeCompare(b.label));   // sort on the raw label, escape at render
             picks.forEach(pk => removeSel.insertAdjacentHTML('beforeend',
-                `<option value="${pk.pickId}" data-player="${pk.playerId}" data-price="${pk.price}">${pk.label}</option>`));
+                `<option value="${pk.pickId}" data-player="${pk.playerId}" data-price="${pk.price}">${esc(pk.label)}</option>`));
         }
 
         async function markTeamDone() {
@@ -1341,8 +1271,8 @@
                     option.className = `player-option ${index === adminHighlightedIndex ? 'highlighted' : ''}`;
                     option.dataset.index = index;
                     option.innerHTML = `
-                        <div class="player-name">${player.first_name} ${player.last_name}</div>
-                        <div class="player-meta">${player.position} - ${player.team}</div>
+                        <div class="player-name">${esc(player.first_name)} ${esc(player.last_name)}</div>
+                        <div class="player-meta">${esc(player.position)} - ${esc(player.team)}</div>
                     `;
                     option.onclick = () => selectAdminPlayer(player.id, `${player.first_name} ${player.last_name}`);
                     dropdown.appendChild(option);
@@ -1479,10 +1409,7 @@
         }
 
         // FOUT guard: reveal once webfonts are ready (--hu/cqw layout depends on metrics).
-        const stage = document.getElementById('stage');
-        function revealStage() { stage.classList.add('ready'); }
-        if (document.fonts && document.fonts.ready) { document.fonts.ready.then(revealStage); }
-        setTimeout(revealStage, 1500);
+        revealOnReady(document.getElementById('stage'));
 
         // Hero height unit: --hu = 1% of the hero's rendered height, so calc(N*var(--hu))
         // in the CSS behaves like the old Ncqh — but works in Firefox, where cqh on a

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -197,6 +197,7 @@
     </div>
     <div id="ptip"></div>
     <div id="vError" class="tb-empty verror-toast"></div>
+    <script src="/static/js/draft-shared.js?v=1"></script>
     {# Hand-tuned single-line JS below; djlint's reformat collapses a // comment over later code. #}
     {# djlint:off #}
     <script>
@@ -233,67 +234,17 @@
         let ledgerSort = 'order', ledgerDir = -1, ledgerQuery = '';   // ledger sort key + direction (-1 desc)
         let availPos = 'ALL', availSort = 'pos', availDir = 1;         // available-board filter + sort
 
-        // NFL Team Logo URLs - using ESPN's CDN
-        function getTeamLogoUrl(teamAbbr) {
-            const teamMappings = {
-                'ARI': 'https://a.espncdn.com/i/teamlogos/nfl/500/ari.png',
-                'ATL': 'https://a.espncdn.com/i/teamlogos/nfl/500/atl.png',
-                'BAL': 'https://a.espncdn.com/i/teamlogos/nfl/500/bal.png',
-                'BUF': 'https://a.espncdn.com/i/teamlogos/nfl/500/buf.png',
-                'CAR': 'https://a.espncdn.com/i/teamlogos/nfl/500/car.png',
-                'CHI': 'https://a.espncdn.com/i/teamlogos/nfl/500/chi.png',
-                'CIN': 'https://a.espncdn.com/i/teamlogos/nfl/500/cin.png',
-                'CLE': 'https://a.espncdn.com/i/teamlogos/nfl/500/cle.png',
-                'DAL': 'https://a.espncdn.com/i/teamlogos/nfl/500/dal.png',
-                'DEN': 'https://a.espncdn.com/i/teamlogos/nfl/500/den.png',
-                'DET': 'https://a.espncdn.com/i/teamlogos/nfl/500/det.png',
-                'GB': 'https://a.espncdn.com/i/teamlogos/nfl/500/gb.png',
-                'HOU': 'https://a.espncdn.com/i/teamlogos/nfl/500/hou.png',
-                'IND': 'https://a.espncdn.com/i/teamlogos/nfl/500/ind.png',
-                'JAX': 'https://a.espncdn.com/i/teamlogos/nfl/500/jax.png',
-                'KC': 'https://a.espncdn.com/i/teamlogos/nfl/500/kc.png',
-                'LV': 'https://a.espncdn.com/i/teamlogos/nfl/500/lv.png',
-                'LAC': 'https://a.espncdn.com/i/teamlogos/nfl/500/lac.png',
-                'LAR': 'https://a.espncdn.com/i/teamlogos/nfl/500/lar.png',
-                'MIA': 'https://a.espncdn.com/i/teamlogos/nfl/500/mia.png',
-                'MIN': 'https://a.espncdn.com/i/teamlogos/nfl/500/min.png',
-                'NE': 'https://a.espncdn.com/i/teamlogos/nfl/500/ne.png',
-                'NO': 'https://a.espncdn.com/i/teamlogos/nfl/500/no.png',
-                'NYG': 'https://a.espncdn.com/i/teamlogos/nfl/500/nyg.png',
-                'NYJ': 'https://a.espncdn.com/i/teamlogos/nfl/500/nyj.png',
-                'PHI': 'https://a.espncdn.com/i/teamlogos/nfl/500/phi.png',
-                'PIT': 'https://a.espncdn.com/i/teamlogos/nfl/500/pit.png',
-                'SF': 'https://a.espncdn.com/i/teamlogos/nfl/500/sf.png',
-                'SEA': 'https://a.espncdn.com/i/teamlogos/nfl/500/sea.png',
-                'TB': 'https://a.espncdn.com/i/teamlogos/nfl/500/tb.png',
-                'TEN': 'https://a.espncdn.com/i/teamlogos/nfl/500/ten.png',
-                'WAS': 'https://a.espncdn.com/i/teamlogos/nfl/500/wsh.png'
-            };
-            
-            return teamMappings[teamAbbr] || `https://a.espncdn.com/i/teamlogos/nfl/500/${teamAbbr.toLowerCase()}.png`;
-        }
+        // esc(), getTeamLogoUrl(), NFL_COLORS/teamColor(), headshotUrl(), budgetClass(),
+        // BOOTH_PERSONAS/BOOTH_LINEUP/boothPersona(), revealOnReady() all come from
+        // /static/js/draft-shared.js (loaded above) — shared with the admin console.
 
-        const headshot = id => `https://a.espncdn.com/combiner/i?img=/i/headshots/nfl/players/full/${id}.png&w=350&h=254`;
-        const logoUrl = abbr => getTeamLogoUrl(abbr);
-        // Per-NFL-team signature colors (ported from the admin console), brightened where
-        // the brand primary is too dark to read on the dark viewer bg. Used for subtle tints.
-        const NFL_COLORS = {
-            ARI:'#C8102E',ATL:'#E31837',BAL:'#5E48A8',BUF:'#1A6DD6',CAR:'#0085CA',CHI:'#E0541C',
-            CIN:'#FB4F14',CLE:'#FF6A2B',DAL:'#2A5BD0',DEN:'#FB4F14',DET:'#1B8FD6',GB:'#3A8C52',
-            HOU:'#C8324B',IND:'#2A74C4',JAX:'#13909E',KC:'#E31837',LV:'#B9C0C4',LAC:'#0FA0E0',
-            LAR:'#2A63E0',MIA:'#00B6C0',MIN:'#6A3CB0',NE:'#D33C50',NO:'#D3BC8D',NYG:'#2A52C9',
-            NYJ:'#2E8C5E',PHI:'#1A8579',PIT:'#FFB612',SEA:'#69BE28',SF:'#C8102E',TB:'#D50A0A',
-            TEN:'#4B92DB',WAS:'#9A3550'
-        };
-        const teamColor = abbr => NFL_COLORS[abbr] || '#E0A24A';
         function hexA(hex, a){ const n = parseInt(hex.slice(1),16); return `rgba(${(n>>16)&255},${(n>>8)&255},${n&255},${a})`; }
         function median(a){ const s=[...a].sort((x,y)=>x-y), m=s.length>>1; return s.length? (s.length%2? s[m] : (s[m-1]+s[m])/2) : 0; }
         function ab2(n){ return (n||'').slice(0,2).toUpperCase(); }
-        const budgetClass = b => { const p = b/INITIAL*100; return p<=15?'crit':p<=35?'warn':'ok'; };
         // D/ST headshot falls back to the team logo (no player headshot for defenses).
         const shotImg = (p, cls) => p.pos === 'D/ST'
-            ? `<img class="${cls} logo" src="${logoUrl(p.nfl)}" alt="">`
-            : `<img class="${cls}" src="${headshot(p.id)}" alt="">`;
+            ? `<img class="${cls} logo" src="${getTeamLogoUrl(p.nfl)}" alt="">`
+            : `<img class="${cls}" src="${headshotUrl(p.id)}" alt="">`;
         function defenseBye(teamAbbr){
             for (const id in playerStats){ const s = playerStats[id]; if (s && s.team === teamAbbr && s.bye_week) return s.bye_week; }
             return null;
@@ -418,10 +369,7 @@
         function maxPickId(ds){ let m = 0; ds.teams.forEach(t => t.picks.forEach(p => { if (p.pick_id > m) m = p.pick_id; })); return m; }
 
         // FOUT guard
-        const app = document.getElementById('app');
-        function reveal(){ app.classList.add('ready'); }
-        if (document.fonts && document.fonts.ready) document.fonts.ready.then(reveal);
-        setTimeout(reveal, 1500);
+        revealOnReady(document.getElementById('app'));
 
         function renderChips(){
           const {clockIdx,nextIdx}=clockInfo();
@@ -433,17 +381,17 @@
               :i===nextIdx?'<span class="chip-badge next">Next</span>'
               :done?'<span class="chip-badge done">✓ Full</span>':'';
             const cls=`chip ${i===selected?'active':''} ${i===clockIdx?'is-clock':''}`;
-            return `<div class="${cls}" style="--tc:${t.color}" onclick="selectTeam(${i})" title="View ${t.team}">
-              <div class="ct">${t.team}</div>
-              <div class="chip-foot"><span class="co">${t.owner}</span>${badge}</div></div>`;
+            return `<div class="${cls}" style="--tc:${t.color}" onclick="selectTeam(${i})" title="View ${esc(t.team)}">
+              <div class="ct">${esc(t.team)}</div>
+              <div class="chip-foot"><span class="co">${esc(t.owner)}</span>${badge}</div></div>`;
           }).join('');
         }
         function renderClockNote(){
           const {clockIdx,nextIdx}=clockInfo();
           const c=clockIdx>=0?TEAMS[clockIdx]:null, n=nextIdx>=0?TEAMS[nextIdx]:null;
           document.getElementById('clocknote').innerHTML=
-            (c?`<span class="cn-clock"><span class="cn-dot"></span>On the Clock <b>${c.team}</b></span>`:'')+
-            (n?`<span class="cn-next">Up Next <b>${n.team}</b></span>`:'');
+            (c?`<span class="cn-clock"><span class="cn-dot"></span>On the Clock <b>${esc(c.team)}</b></span>`:'')+
+            (n?`<span class="cn-next">Up Next <b>${esc(n.team)}</b></span>`:'');
         }
         function renderChrome() {
             renderChips();
@@ -480,10 +428,10 @@
         });
 
         function renderIdentity() {
-            const t = TEAMS[selected], bc = budgetClass(t.budget), spent = INITIAL - t.budget;
+            const t = TEAMS[selected], bc = budgetClass(t.budget, INITIAL), spent = INITIAL - t.budget;
             const el = document.getElementById('identity'); el.style.setProperty('--tc', t.color);
             el.innerHTML = `
-    <div class="id-main"><span class="id-name cond">${t.team}</span><span class="id-eyebrow">Managed by <b>${t.owner}</b></span></div>
+    <div class="id-main"><span class="id-name cond">${esc(t.team)}</span><span class="id-eyebrow">Managed by <b>${esc(t.owner)}</b></span></div>
     <div class="id-stats">
       <div class="idstat"><span class="k">Budget</span><b class="v money ${bc} tnum">$${t.budget}</b></div>
       <div class="idstat"><span class="k">Max Bid</span><b class="v max tnum">${t.picks >= TOTAL ? '—' : '$' + maxBid(t)}</b></div>
@@ -505,25 +453,7 @@
         function activeViewId() { const a = document.querySelector('.view.active'); return a ? a.id : 'view-teams'; }
 
         // ---- The Booth: live analyst commentary (/api/v1/comments) ----
-        // Per-persona identity: accent ring + headshot file (or initials fallback).
-        const BOOTH_PERSONAS = {
-            eisen:    { accent: '#E8A33D', slug: 'eisen',    name: 'Rich Eisen' },
-            kiper:    { accent: '#56C5D0', slug: 'kiper',    name: 'Mel Kiper Jr.' },
-            schefter: { accent: '#E2574C', slug: 'schefter', name: 'Adam Schefter' },
-            booger:   { accent: '#5BBF7B', slug: 'booger',   name: 'Booger McFarland' },
-            kimes:    { accent: '#9B8CEF', slug: 'kimes',    name: 'Mina Kimes' },
-            mcafee:   { accent: '#F0913E', slug: 'mcafee',   name: 'Pat McAfee' },
-        };
-        const BOOTH_LINEUP = ['eisen', 'kiper', 'schefter', 'booger', 'kimes', 'mcafee'];
-        function boothPersona(name) {
-            const key = (name || '').toLowerCase().replace(/[^a-z]/g, '');
-            const m = BOOTH_PERSONAS[key];
-            const label = (name || '?').toUpperCase();
-            const initials = (name || '?').replace(/[^A-Za-z]/g, '').slice(0, 2).toUpperCase() || '?';
-            return m
-                ? { key, label, fullName: m.name, accent: m.accent, img: `/static/img/personas/${m.slug}.jpg`, initials }
-                : { key, label, fullName: (name || ''), accent: 'var(--slate)', img: '', initials };
-        }
+        // Persona identity (BOOTH_PERSONAS / BOOTH_LINEUP / boothPersona) lives in draft-shared.js.
         let boothMaxSeq = 0;          // newest seq shown (live-tail watermark)
         let boothMinSeq = null;       // oldest seq shown (backward-paging cursor)
         let boothPinned = true;       // user is parked at the live edge
@@ -718,11 +648,11 @@
                 const byeChip = p.bye ? `<span class="pc-bye tnum">BYE ${p.bye}</span>` : '';
                 html += `<div class="pcard" style="--pc:${POSCOLOR[p.pos]};--tmc:${teamColor(p.nfl)}" data-idx="${idx}" onmouseenter="showTip(event,${idx})" onmousemove="moveTip(event)" onmouseleave="hideTip()">
       <div class="pc-photo">
-        <img class="pc-wm" src="${logoUrl(p.nfl)}" alt="">
+        <img class="pc-wm" src="${getTeamLogoUrl(p.nfl)}" alt="">
         ${shotImg(p, 'pc-shot')}
         <span class="pc-pos ${LIGHTPOS[p.pos] ? 'light' : ''}">${p.pos}</span>
         <div class="pc-corner"><span class="pc-price tnum">$${p.price}</span>${byeChip}</div>
-        <div class="pc-scrim"><div class="pc-name">${p.fn} ${p.ln}</div><div class="pc-sub">${p.nfl}</div></div>
+        <div class="pc-scrim"><div class="pc-name">${esc(p.fn)} ${esc(p.ln)}</div><div class="pc-sub">${esc(p.nfl)}</div></div>
       </div>
       <div class="pc-stats">${cells}</div>
     </div>`;
@@ -742,7 +672,7 @@
                 const hot = Object.entries(pb).filter(([k, v]) => SKILL[k] && v >= 2);
                 const flag = hot.length ? hot.map(([k, v]) => `${v}× ${k}`).join(' · ') : '';
                 const chips = items.sort((a, b) => POSORDER[a.p.pos] - POSORDER[b.p.pos]).map(({ p, idx }) =>
-                    `<div class="bw-chip" style="--pc:${POSCOLOR[p.pos]};--tmc:${teamColor(p.nfl)}" data-idx="${idx}" onmouseenter="showTip(event,${idx})" onmousemove="moveTip(event)" onmouseleave="hideTip()"><span class="bw-pos">${p.pos}</span><span class="bw-nm">${p.ln}</span></div>`).join('');
+                    `<div class="bw-chip" style="--pc:${POSCOLOR[p.pos]};--tmc:${teamColor(p.nfl)}" data-idx="${idx}" onmouseenter="showTip(event,${idx})" onmousemove="moveTip(event)" onmouseleave="hideTip()"><span class="bw-pos">${p.pos}</span><span class="bw-nm">${esc(p.ln)}</span></div>`).join('');
                 return `<div class="bye-wk ${hot.length ? 'exposed' : ''}">
                     <div class="bw-head"><span class="bw-num cond">WK ${w}</span><span class="bw-cnt">${items.length}</span></div>
                     ${flag ? `<div class="bw-flag">${flag}</div>` : '<div class="bw-flag ok">covered</div>'}
@@ -760,8 +690,8 @@
                 const byeCls = curRoster.filter(q => q.bye && q.bye === p.bye && SKILL[q.pos] && q.pos === p.pos).length >= 2 ? ' clash' : '';
                 html += `<div class="rl-row" style="--tmc:${teamColor(p.nfl)}" data-idx="${idx}" onmouseenter="showTip(event,${idx})" onmousemove="moveTip(event)" onmouseleave="hideTip()">
                     <span class="rl-pos" style="background:${POSCOLOR[p.pos]}${LIGHTPOS[p.pos] ? ';color:#fff' : ''}">${p.pos}</span>
-                    <span class="rl-nm">${p.fn} ${p.ln}</span>
-                    <span class="rl-team">${p.nfl}</span>
+                    <span class="rl-nm">${esc(p.fn)} ${esc(p.ln)}</span>
+                    <span class="rl-team">${esc(p.nfl)}</span>
                     <span class="rl-c rl-bye${byeCls}">${p.bye || '—'}</span>
                     <span class="rl-c rl-stat"><b class="tnum">${key[1]}</b><i>${key[0]}</i></span>
                     <span class="rl-c rl-price tnum">$${p.price}</span></div>`;
@@ -860,9 +790,9 @@
             el.innerHTML = `<div class="la-body">
                 <div class="la-photo"><span class="la-pos" style="background:${POSCOLOR[p.pos]}">${p.pos}</span>${shotImg(p, '')}</div>
                 <div class="la-info"><div class="la-eyebrow">Now Auctioning <span class="la-live"><span class="d"></span>LIVE</span></div>
-                  <div class="la-name cond">${p.fn} ${p.ln}</div><div class="la-sub">${p.nfl} · ${p.pos}</div></div>
+                  <div class="la-name cond">${esc(p.fn)} ${esc(p.ln)}</div><div class="la-sub">${esc(p.nfl)} · ${p.pos}</div></div>
                 <div class="la-bid"><div class="k">Current Bid</div><div class="v tnum">$${nom.current_bid}</div>
-                  <div class="la-bidder"><span class="dot" style="background:${bidder ? bidder.color : '#888'}"></span>${bidder ? bidder.team_name : '—'}</div></div>
+                  <div class="la-bidder"><span class="dot" style="background:${bidder ? bidder.color : '#888'}"></span>${bidder ? esc(bidder.team_name) : '—'}</div></div>
             </div>`;
         }
 
@@ -916,8 +846,8 @@
                 return `<div class="ld-row${isNew ? ' ld-new' : ''}" style="--tmc:${teamColor(r.nfl)}">
                     <span class="ld-no tnum">${r.ord}</span>
                     <span class="ld-pos" style="background:${POSCOLOR[r.pos]}${LIGHTPOS[r.pos] ? ';color:#fff' : ''}">${r.pos}</span>
-                    <span class="ld-name">${r.name} <i>${r.nfl}</i></span>
-                    <span class="ld-team"><span class="ld-dot" style="background:${r.color}"></span>${r.team}</span>
+                    <span class="ld-name">${esc(r.name)} <i>${esc(r.nfl)}</i></span>
+                    <span class="ld-team"><span class="ld-dot" style="background:${r.color}"></span>${esc(r.team)}</span>
                     <span class="ld-price tnum ${pcls}">$${r.price}</span></div>`;
             }).join('');
         }
@@ -970,8 +900,8 @@
                 const bye = byeOf(p);
                 return `<div class="av-row">
                     <span class="av-pos" style="background:${POSCOLOR[p.pos]}${LIGHTPOS[p.pos] ? ';color:#fff' : ''}">${p.pos}</span>
-                    <span class="av-nm">${p.fn} ${p.ln}</span>
-                    <span class="av-team">${p.nfl}</span>
+                    <span class="av-nm">${esc(p.fn)} ${esc(p.ln)}</span>
+                    <span class="av-team">${esc(p.nfl)}</span>
                     <span class="av-bye tnum">${bye || '—'}</span>
                     <span class="av-prod tnum">${prodShort(p)}</span></div>`;
             }).join('');
@@ -983,7 +913,7 @@
             document.getElementById('budgetPower').innerHTML = ranked.map((t, i) => {
                 const mb = t.picks >= TOTAL ? '—' : '$' + maxBid(t);
                 return `<div class="mn-row"><span class="mn-rank tnum">${i + 1}</span>
-                    <span class="mn-name"><span class="mn-dot" style="background:${t.color}"></span><span class="nm">${t.team}</span></span>
+                    <span class="mn-name"><span class="mn-dot" style="background:${t.color}"></span><span class="nm">${esc(t.team)}</span></span>
                     <span class="mn-track"><span class="mn-fill" style="width:${t.budget / INITIAL * 100}%"></span></span>
                     <span class="mn-val tnum rt">$${t.budget}</span>
                     <span class="mn-max tnum rt" title="Max bid this team can still place">${mb}</span></div>`;
@@ -1002,7 +932,7 @@
         function tbRow(p, cls, btn) {
             return `<div class="${cls}" draggable="true" data-id="${p.id}">
           <span class="tb-pos" style="background:${POSCOLOR[p.pos]}${LIGHTPOS[p.pos] ? ';color:#fff' : ''}">${p.pos}</span>
-          <span class="tb-nm">${p.fn} ${p.ln}</span><span class="tb-meta">${p.nfl}</span>${btn}</div>`;
+          <span class="tb-nm">${esc(p.fn)} ${esc(p.ln)}</span><span class="tb-meta">${esc(p.nfl)}</span>${btn}</div>`;
         }
         function renderResults() {
             const q = document.getElementById('tbSearch').value.trim().toLowerCase(), box = document.getElementById('tbResults');
@@ -1086,8 +1016,8 @@
             const rows = det.length
                 ? det.map(c => { const n = num(c[1]); return `<div class="tt-stat"><span class="l">${c[0]}</span><span class="bar"><i style="width:${n != null ? Math.min(n / c[2] * 100, 100) : 0}%"></i></span><span class="n tnum">${c[1] == null ? '–' : c[1]}</span></div>`; }).join('')
                 : '<div class="tt-none">No box-score stats for this position.</div>';
-            tip.innerHTML = `<div class="tt-head"><span class="tt-pos ${LIGHTPOS[p.pos] ? 'light' : ''}" style="background:${POSCOLOR[p.pos]}">${p.pos}</span><span class="tt-name">${p.fn} ${p.ln}</span></div>
-                <div class="tt-sub">${p.nfl}${p.bye ? ' · Bye ' + p.bye : ''}</div>
+            tip.innerHTML = `<div class="tt-head"><span class="tt-pos ${LIGHTPOS[p.pos] ? 'light' : ''}" style="background:${POSCOLOR[p.pos]}">${p.pos}</span><span class="tt-name">${esc(p.fn)} ${esc(p.ln)}</span></div>
+                <div class="tt-sub">${esc(p.nfl)}${p.bye ? ' · Bye ' + p.bye : ''}</div>
                 ${priceCtx(p.pos, p.price)}
                 <div class="tt-stats">${rows}</div>`;
             tip.style.display = 'block'; moveTip(e);
@@ -1154,7 +1084,7 @@
                     const jitter = ((i % 5) - 2) * 4.2;
                     const cx = X(l.price).toFixed(1), yy = (cy + jitter).toFixed(1);
                     const z = (l.price - m.md) / (m.sd || 1), isDump = DUMPS.has(l.pickId);
-                    const data = `data-n="${l.name}" data-pos="${pos}" data-pr="${l.price}" data-tm="${l.teamName}" data-z="${z.toFixed(1)}" data-dump="${isDump ? 1 : ''}"`;
+                    const data = `data-n="${esc(l.name)}" data-pos="${pos}" data-pr="${l.price}" data-tm="${esc(l.teamName)}" data-z="${z.toFixed(1)}" data-dump="${isDump ? 1 : ''}"`;
                     s += `<circle class="an-dot ${isDump ? 'an-dump' : ''}" cx="${cx}" cy="${yy}" r="${isDump ? 4.5 : 4}" style="--pc:${POSCOLOR[pos]};fill:${isDump ? 'none' : POSCOLOR[pos]};stroke:${isDump ? POSCOLOR[pos] : 'none'}"/><circle class="an-hit" cx="${cx}" cy="${yy}" r="9" ${data}/>`;
                 });
                 if (inV(m.md)) {
@@ -1228,8 +1158,8 @@
                 ? `<div class="tt-ctx dump"><b>$${pr}</b> · final-pick budget dump · leftover money</div>`
                 : (t ? ctxHTML(pos, pr, t) : `<div class="tt-ctx mid"><b>$${pr}</b></div>`);
             tip.style.setProperty('--pc', POSCOLOR[pos]);
-            tip.innerHTML = `<div class="tt-head"><span class="tt-pos ${LIGHTPOS[pos] ? 'light' : ''}" style="background:${POSCOLOR[pos]}">${pos}</span><span class="tt-name">${c.dataset.n}</span></div>
-                <div class="tt-sub">${c.dataset.tm}</div>${ctx}`;
+            tip.innerHTML = `<div class="tt-head"><span class="tt-pos ${LIGHTPOS[pos] ? 'light' : ''}" style="background:${POSCOLOR[pos]}">${pos}</span><span class="tt-name">${esc(c.dataset.n)}</span></div>
+                <div class="tt-sub">${esc(c.dataset.tm)}</div>${ctx}`;
             tip.style.display = 'block'; moveTip(e);
         }
         function setMatrixMode(m) {
@@ -1251,7 +1181,7 @@
             let html = `<div class="mx-grid" style="grid-template-columns:minmax(96px,1.3fr) repeat(${order.length},1fr)">`;
             html += `<div class="mx-corner"></div>` + order.map(pos => `<div class="mx-h" style="color:${POSCOLOR[pos]}">${pos}${dollars ? '' : `<i>/${POSMAX[pos]}</i>`}</div>`).join('');
             rows.forEach(({ t, count, spend }) => {
-                html += `<div class="mx-team"><span class="mx-dot" style="background:${t.color}"></span><span class="nm">${t.team}</span></div>`;
+                html += `<div class="mx-team"><span class="mx-dot" style="background:${t.color}"></span><span class="nm">${esc(t.team)}</span></div>`;
                 order.forEach(pos => {
                     const n = count[pos] || 0, dol = spend[pos] || 0;
                     const val = dollars ? dol : n, max = POSMAX[pos] || 1;
@@ -1261,7 +1191,7 @@
                     const cls = 'mx-cell' + (val === 0 ? ' empty' : '') + (full ? ' full' : '');
                     const label = dollars ? (dol ? '$' + dol : '·') : (n || '·');
                     const title = dollars ? `${t.team} · ${pos} $${dol}` : `${t.team} · ${pos} ${n}/${max}`;
-                    html += `<div class="${cls}" style="background:${bg}" title="${title}"><span class="mx-n">${label}</span></div>`;
+                    html += `<div class="${cls}" style="background:${bg}" title="${esc(title)}"><span class="mx-n">${label}</span></div>`;
                 });
             });
             html += '</div>';
@@ -1281,7 +1211,7 @@
             const cards = [];
             let splurge = null;
             log.forEach(l => { if (DUMPS.has(l.pickId)) return; const m = MARKET[l.pos]; if (!m || l.price <= 1) return; const over = l.price - m.md; if (!splurge || over > splurge.over) splurge = { ...l, over, md: m.md }; });
-            if (splurge) cards.push({ accent: POSCOLOR[splurge.pos], eyebrow: 'Biggest Splurge', val: `$${splurge.price}`, sub: `${splurge.name} · $${splurge.over} over typical ${splurge.pos} ($${splurge.md})` });
+            if (splurge) cards.push({ accent: POSCOLOR[splurge.pos], eyebrow: 'Biggest Splurge', val: `$${splurge.price}`, sub: `${esc(splurge.name)} · $${splurge.over} over typical ${splurge.pos} ($${splurge.md})` });
             let topPos = null;
             RADAR_ORDER.forEach(pos => { const m = MARKET[pos]; if (m && (!topPos || m.total > topPos.total)) topPos = { pos, ...m }; });
             if (topPos) cards.push({ accent: POSCOLOR[topPos.pos], eyebrow: 'Where The Money Went', val: topPos.pos, sub: `$${topPos.total} over ${topPos.n} picks · median $${topPos.md}` });
@@ -1289,7 +1219,7 @@
             if (run.len >= 2) cards.push({ accent: POSCOLOR[run.pos], eyebrow: 'Hottest Run', val: `${run.len}× ${run.pos}`, sub: `picks ${run.start}–${run.end} all went ${run.pos}` });
             let conc = null;
             TEAMS.forEach(t => { const ps = t._picks.filter(p => !DUMPS.has(p.pick_id)).map(p => p.price), spent = ps.reduce((s, v) => s + v, 0); if (spent < 10 || !ps.length) return; const top = Math.max(...ps), share = top / spent; if (!conc || share > conc.share) conc = { team: t.team, share, top, spent }; });
-            if (conc) cards.push({ accent: 'var(--gold)', eyebrow: 'Stars & Scrubs', val: `${Math.round(conc.share * 100)}%`, sub: `${conc.team} — $${conc.top} of $${conc.spent} spent on one player` });
+            if (conc) cards.push({ accent: 'var(--gold)', eyebrow: 'Stars & Scrubs', val: `${Math.round(conc.share * 100)}%`, sub: `${esc(conc.team)} — $${conc.top} of $${conc.spent} spent on one player` });
             box.innerHTML = cards.map(c => `<div class="insight" style="--ac:${c.accent}"><div class="in-eyebrow">${c.eyebrow}</div><div class="in-val cond">${c.val}</div><div class="in-sub">${c.sub}</div></div>`).join('');
         }
         function renderTempo() {
@@ -1301,7 +1231,7 @@
             s += `<line class="an-axis" x1="${padL}" y1="${Y0}" x2="${W - padR}" y2="${Y0}"/>`;
             log.forEach((l, i) => {
                 const h = Math.max(2, (l.price / maxP) * (H - padT - padB)), x = padL + i * bw;
-                const data = `data-n="${l.name}" data-pos="${l.pos}" data-pr="${l.price}" data-tm="${l.teamName}" data-no="${l.no}"`;
+                const data = `data-n="${esc(l.name)}" data-pos="${l.pos}" data-pr="${l.price}" data-tm="${esc(l.teamName)}" data-no="${l.no}"`;
                 s += `<rect class="tp-bar" x="${x.toFixed(1)}" y="${(Y0 - h).toFixed(1)}" width="${Math.max(1, bw - 0.7).toFixed(1)}" height="${h.toFixed(1)}" style="fill:${POSCOLOR[l.pos]}"/>`;
                 // Full-height hit target so even tiny bars are easy to hover.
                 s += `<rect class="tp-hit" x="${x.toFixed(1)}" y="${padT}" width="${bw.toFixed(2)}" height="${(Y0 - padT).toFixed(1)}" ${data}/>`;
@@ -1313,8 +1243,8 @@
         function showTempoTip(e, b) {
             const tip = document.getElementById('ptip'), pos = b.dataset.pos;
             tip.style.setProperty('--pc', POSCOLOR[pos]);
-            tip.innerHTML = `<div class="tt-head"><span class="tt-pos ${LIGHTPOS[pos] ? 'light' : ''}" style="background:${POSCOLOR[pos]}">${pos}</span><span class="tt-name">${b.dataset.n}</span></div>
-                <div class="tt-sub">Pick ${b.dataset.no} · ${b.dataset.tm}</div>
+            tip.innerHTML = `<div class="tt-head"><span class="tt-pos ${LIGHTPOS[pos] ? 'light' : ''}" style="background:${POSCOLOR[pos]}">${pos}</span><span class="tt-name">${esc(b.dataset.n)}</span></div>
+                <div class="tt-sub">Pick ${b.dataset.no} · ${esc(b.dataset.tm)}</div>
                 <div class="tt-ctx mid"><b>$${b.dataset.pr}</b></div>`;
             tip.style.display = 'block'; moveTip(e);
         }
@@ -1325,8 +1255,8 @@
             const t = valueTier(pos, pr);
             const ctx = t ? ctxHTML(pos, pr, t) : `<div class="tt-ctx mid"><b>$${pr}</b></div>`;
             tip.style.setProperty('--pc', POSCOLOR[pos]);
-            tip.innerHTML = `<div class="tt-head"><span class="tt-pos ${LIGHTPOS[pos] ? 'light' : ''}" style="background:${POSCOLOR[pos]}">${pos}</span><span class="tt-name">${el.dataset.n}</span></div>
-                <div class="tt-sub">${el.dataset.tm}</div>${ctx}`;
+            tip.innerHTML = `<div class="tt-head"><span class="tt-pos ${LIGHTPOS[pos] ? 'light' : ''}" style="background:${POSCOLOR[pos]}">${pos}</span><span class="tt-name">${esc(el.dataset.n)}</span></div>
+                <div class="tt-sub">${esc(el.dataset.tm)}</div>${ctx}`;
             tip.style.display = 'block'; moveTip(e);
         }
 
@@ -1374,9 +1304,9 @@
             if (!under.length && !over.length) { wrap.innerHTML = '<div class="an-empty">Bargains surface once at least four players at a position are sold.</div>'; return; }
             const row = (f, kind) => {
                 const delta = kind === 'under' ? `$${f.md - f.price} under typical` : `$${f.price - f.md} over typical`;
-                return `<div class="bg-row ${kind}" data-n="${f.name}" data-pos="${f.pos}" data-pr="${f.price}" data-tm="${f.team}" onmouseenter="showCtxTip(event,this)" onmousemove="moveTip(event)" onmouseleave="hideTip()">
+                return `<div class="bg-row ${kind}" data-n="${esc(f.name)}" data-pos="${f.pos}" data-pr="${f.price}" data-tm="${esc(f.team)}" onmouseenter="showCtxTip(event,this)" onmousemove="moveTip(event)" onmouseleave="hideTip()">
                     <span class="bg-pos" style="background:${POSCOLOR[f.pos]}${LIGHTPOS[f.pos] ? ';color:#fff' : ''}">${f.pos}</span>
-                    <span class="bg-main"><span class="bg-nm">${f.name} <i>${f.nfl}</i></span><span class="bg-sub">${f.pos}#${f.prodRank} of ${f.n} by ${STATS_YR} production · to ${f.team}</span></span>
+                    <span class="bg-main"><span class="bg-nm">${esc(f.name)} <i>${esc(f.nfl)}</i></span><span class="bg-sub">${f.pos}#${f.prodRank} of ${f.n} by ${STATS_YR} production · to ${esc(f.team)}</span></span>
                     <span class="bg-right"><span class="bg-price">$${f.price}</span><span class="bg-delta">${delta}</span></span></div>`;
             };
             const grp = (label, kind, items, empty) => `<div class="bg-group"><div class="bg-glabel ${kind}">${label}</div>${items.length ? items.slice(0, 6).map(f => row(f, kind)).join('') : `<div class="bg-none">${empty}</div>`}</div>`;
@@ -1409,10 +1339,10 @@
             s += `<text class="bp-axlbl" transform="translate(12,${(padT + (H - padB - padT) / 2).toFixed(0)}) rotate(-90)" text-anchor="middle">← BUDGET LEFT</text>`;
             pts.forEach(p => {
                 const cx = X(p.spots), cy = Y(p.budget), sel = p.i === selected;
-                const data = `data-tm="${p.team}" data-ow="${p.owner}" data-bu="${p.budget}" data-sp="${p.spots}" data-mb="${p.mb}" data-cl="${p.color}"`;
+                const data = `data-tm="${esc(p.team)}" data-ow="${esc(p.owner)}" data-bu="${p.budget}" data-sp="${p.spots}" data-mb="${p.mb}" data-cl="${p.color}"`;
                 s += `<circle class="bp-dot ${sel ? 'sel' : ''}" cx="${cx.toFixed(1)}" cy="${cy.toFixed(1)}" r="${sel ? 7 : 5.5}" style="fill:${p.color}"/>`;
                 s += `<circle class="bp-hit" cx="${cx.toFixed(1)}" cy="${cy.toFixed(1)}" r="13" ${data}/>`;
-                s += `<text class="bp-lbl ${sel ? 'sel' : ''}" x="${(cx + 9).toFixed(1)}" y="${(cy + 3.5).toFixed(1)}">${p.owner}</text>`;
+                s += `<text class="bp-lbl ${sel ? 'sel' : ''}" x="${(cx + 9).toFixed(1)}" y="${(cy + 3.5).toFixed(1)}">${esc(p.owner)}</text>`;
             });
             s += '</svg>';
             wrap.innerHTML = s;
@@ -1421,8 +1351,8 @@
         function showBuyingTip(e, c) {
             const tip = document.getElementById('ptip');
             tip.style.setProperty('--pc', c.dataset.cl);
-            tip.innerHTML = `<div class="tt-head"><span class="tt-name">${c.dataset.tm}</span></div>
-                <div class="tt-sub">${c.dataset.ow}</div>
+            tip.innerHTML = `<div class="tt-head"><span class="tt-name">${esc(c.dataset.tm)}</span></div>
+                <div class="tt-sub">${esc(c.dataset.ow)}</div>
                 <div class="bp-tt"><span>Budget left</span><b class="tnum">$${c.dataset.bu}</b></div>
                 <div class="bp-tt"><span>Spots left</span><b class="tnum">${c.dataset.sp}</b></div>
                 <div class="bp-tt"><span>Max single bid</span><b class="tnum gold">$${c.dataset.mb}</b></div>`;
@@ -1449,11 +1379,11 @@
             wrap.innerHTML = rows.map(({ t, picks, spent }) => {
                 const chips = picks.slice(0, 3).map(p => {
                     const tag = p.dump ? '<i class="tbuy-tag" title="Final-pick budget dump — leftover money, not a target">dump</i>' : '';
-                    return `<span class="tbuy-chip ${p.dump ? 'is-dump' : ''}" style="--pc:${POSCOLOR[p.pos]}" data-n="${p.fn} ${p.ln}" data-pos="${p.pos}" data-pr="${p.price}" data-tm="${t.team}" onmouseenter="showCtxTip(event,this)" onmousemove="moveTip(event)" onmouseleave="hideTip()"><span class="tbuy-cpos">${p.pos}</span><span class="tbuy-cnm">${p.ln}</span><span class="tbuy-cpr">$${p.price}</span>${tag}</span>`;
+                    return `<span class="tbuy-chip ${p.dump ? 'is-dump' : ''}" style="--pc:${POSCOLOR[p.pos]}" data-n="${esc(p.fn + ' ' + p.ln)}" data-pos="${p.pos}" data-pr="${p.price}" data-tm="${esc(t.team)}" onmouseenter="showCtxTip(event,this)" onmousemove="moveTip(event)" onmouseleave="hideTip()"><span class="tbuy-cpos">${p.pos}</span><span class="tbuy-cnm">${esc(p.ln)}</span><span class="tbuy-cpr">$${p.price}</span>${tag}</span>`;
                 }).join('');
                 const more = picks.length > 3 ? `<span class="tbuy-more">+${picks.length - 3} more</span>` : '';
                 return `<div class="tbuy-row ${t.owner_id === selOwner ? 'sel' : ''}">
-                    <span class="tbuy-team"><span class="tbuy-dot" style="background:${t.color}"></span><span class="nm">${t.team}</span></span>
+                    <span class="tbuy-team"><span class="tbuy-dot" style="background:${t.color}"></span><span class="nm">${esc(t.team)}</span></span>
                     <span class="tbuy-chips">${chips}${more}</span>
                     <span class="tbuy-spent tnum">$${spent}</span></div>`;
             }).join('');


### PR DESCRIPTION
## Summary

Phase 2 of the frontend review remediation (`FRONTEND_REVIEW.md`). Three tightly coupled items done in one pass:

- **F2 — HTML escaping sweep**: Added `esc()` helper and applied it to every interpolation of owner/team/player names into `innerHTML` and HTML attributes across both templates. Covers all render functions listed in the review plus additional sites found during the sweep (`heroStatLine`, `renderMatrix` titles, `renderInsights` cards, `renderBuying` SVG text, and all five tooltip builders' `data-*` → `dataset` → `innerHTML` round-trips). Booth comment text left on the safe `createElement`/`textContent` path.
- **F3 — WAS logo fix**: Settled on ESPN's `wsh` slug (both `was.png` and `wsh.png` resolve, but the templates had drifted). Added `onerror` hide to `#hero-logo` with an un-hide guard so one failed load doesn't hide the logo for the rest of the draft.
- **R1 — Shared JS extraction**: Created `static/js/draft-shared.js` (134 lines) containing `esc()`, `getTeamLogoUrl()`, `NFL_COLORS`/`teamColor()`, `headshotUrl()`, `BOOTH_PERSONAS`/`boothPersona()`, `budgetClass()`, `revealOnReady()`. Reconciled differing signatures (`budgetClass` took different args, `getTeamColor` vs `NFL_COLORS` shapes). Both access patterns (`NFL_COLORS['KC']` and `teamColor('KC')`) available from the shared file. Inline copies deleted from both templates — verified no `teamlogos/nfl/500` or `BOOTH_PERSONAS` definitions remain in template files.

Net: **+214 / -223 lines** across 3 files (templates got shorter despite the escaping additions).

## Test plan

- [ ] 353 tests pass (`python -m pytest tests/ -x -q`)
- [ ] `ruff check` clean, `djlint templates/` only pre-existing H020
- [ ] `grep teamlogos/nfl/500 templates/` → no matches (only in shared file)
- [ ] Manual: set an owner name to `<img src=x onerror=alert(1)> "quote'` — literal text displays in both panels, no alert, no broken layout
- [ ] Manual: WAS player logo renders in admin hero panel
- [ ] Manual: all viewer tabs render (Teams/Ledger/Available), tooltips work
- [ ] Manual: booth persona avatars and color rings display correctly
- [ ] Manual: budget health classes (ok/warn/crit) show correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)