### PR TITLE
refactor: keyboard/ARIA accessibility and misc improvements (R4, R5)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -276,7 +276,7 @@ Pydantic Models (Python) → FastAPI Endpoints → OpenAPI Schema
 ### Models (src/models/)
 
 **Player** (`player.py`): Core player representation (immutable)
-- `id: int` - Unique identifier for image retrieval
+- `id: int` - **Must be an ESPN player ID.** Both `headshotUrl()` (in `draft-shared.js`) and `getTeamLogoUrl()` build ESPN CDN URLs from this ID. If `players.json` is regenerated from a non-ESPN source, headshot/photo URLs will 404.
 - `first_name: str` - Player's first name
 - `last_name: str` - Player's last name  
 - `team: NFLTeam` - NFL team (validated enum)

--- a/src/booth/slice.py
+++ b/src/booth/slice.py
@@ -62,6 +62,9 @@ def production_score(stats: PlayerStats | None) -> float:
     A deterministic, market-derived proxy for "how productive was this player
     last season" — used only to ORDER players within a position. Players with
     no recorded production score 0.0 (and are flagged as rookies elsewhere).
+
+    Production score -- intentionally distinct from the viewer's prodScore()
+    (static/js/team-viewer.js) and ledger price tiers (valueTier, same file).
     """
     if stats is None:
         return 0.0

--- a/static/css/draft-set-viewer.css
+++ b/static/css/draft-set-viewer.css
@@ -67,6 +67,8 @@ body{
 .chip-badge.next{background:rgba(224,162,74,.16);color:var(--electric);border:1px solid rgba(224,162,74,.5);}
 .chip.is-clock{border-color:var(--gold) !important;box-shadow:0 0 0 1px var(--gold),0 6px 18px rgba(255,199,44,.25);animation:chipglow 2.2s ease-in-out infinite;}
 @keyframes chipglow{50%{box-shadow:0 0 0 1px var(--gold),0 0 22px rgba(255,199,44,.5);}}
+/* Button reset for team chips (div → button for keyboard access) */
+button.chip{font:inherit;color:inherit;text-align:left;-webkit-appearance:none;appearance:none;}
 
 /* ---------- VIEWS ---------- */
 .view{flex:1;min-height:0;display:none;}
@@ -543,6 +545,13 @@ body{
 .booth-jump{position:absolute;bottom:12px;left:50%;transform:translateX(-50%);font-family:'Saira Condensed';font-weight:800;
   font-size:12px;letter-spacing:1px;text-transform:uppercase;color:var(--accent-ink,#1A1206);background:var(--electric);
   border:none;border-radius:20px;padding:6px 14px;cursor:pointer;box-shadow:0 6px 18px rgba(0,0,0,.4);}
+
+/* ---------- FOCUS STYLES (keyboard/ARIA accessibility) ---------- */
+button:focus-visible,
+[role="button"]:focus-visible{
+  outline:2px solid var(--electric);
+  outline-offset:2px;
+}
 
 /* Respect prefers-reduced-motion (plan §2 global constraint) — disable
    ambient/looping animations and shorten transitions for users who request it. */

--- a/static/js/draft-admin.js
+++ b/static/js/draft-admin.js
@@ -26,6 +26,30 @@
         let adminHighlightedIndex = -1;
         let cursorIndex = null;   // keyboard bid cursor: index into draftState.teams
 
+        // Shared fetch wrapper for mutating endpoints: standardizes 409 (version
+        // conflict) handling across all admin actions.  GET-only fetches stay raw.
+        async function apiCall(url, opts, {onSuccess, label = 'Action'} = {}) {
+            try {
+                const res = await fetch(url, opts);
+                if (res.status === 409) {
+                    await refreshData();
+                    showMessage(`${label}: state changed — please retry`, 'error');
+                    return null;
+                }
+                if (!res.ok) {
+                    const err = await res.json().catch(() => ({detail: res.statusText}));
+                    showMessage(`${label} failed: ${err.detail}`, 'error');
+                    return null;
+                }
+                const data = await res.json();
+                if (onSuccess) onSuccess(data);
+                return data;
+            } catch (e) {
+                showMessage(`${label}: ${e.message}`, 'error');
+                return null;
+            }
+        }
+
         function openDrawer() {
             document.getElementById('scrim').classList.add('open');
             document.getElementById('drawer').classList.add('open');
@@ -614,35 +638,26 @@
                 }
             }
 
-            try {
-                const response = await fetch('/api/v1/nominate', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        owner_id: currentDraftState ? currentDraftState.next_to_nominate : 1,
-                        player_id: selectedPlayerId,
-                        initial_bid: bid,
-                        expected_version: currentVersion
-                    })
-                });
-                
-                if (response.ok) {
-                    const result = await response.json();
-                    showMessage('Player nominated successfully!', 'success');
-                    currentVersion = result.new_version;
-                    await refreshData();
-                    document.getElementById('nomination-bid').value = '1';
-                    document.getElementById('player-search').value = '';
-                    document.getElementById('player-search').blur();   // hand off to the bid console
-                    selectedPlayerId = null;
-                    selectedPlayerName = null;
-                } else {
-                    const error = await response.json();
-                    showMessage('Nomination failed: ' + error.detail, 'error');
-                }
-            } catch (error) {
-                showMessage('Error nominating player: ' + error.message, 'error');
-            }
+            const data = await apiCall('/api/v1/nominate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    owner_id: currentDraftState ? currentDraftState.next_to_nominate : 1,
+                    player_id: selectedPlayerId,
+                    initial_bid: bid,
+                    expected_version: currentVersion
+                })
+            }, { label: 'Nomination' });
+            if (!data) return;
+
+            showMessage('Player nominated successfully!', 'success');
+            currentVersion = data.new_version;
+            await refreshData();
+            document.getElementById('nomination-bid').value = '1';
+            document.getElementById('player-search').value = '';
+            document.getElementById('player-search').blur();   // hand off to the bid console
+            selectedPlayerId = null;
+            selectedPlayerName = null;
         }
 
         async function placeBidForOwner(ownerId, amountOverride) {
@@ -656,32 +671,23 @@
                 return;
             }
 
-            try {
-                const response = await fetch('/api/v1/bid', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        owner_id: ownerId,
-                        bid_amount: bid,
-                        expected_version: currentVersion
-                    })
-                });
+            const data = await apiCall('/api/v1/bid', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    owner_id: ownerId,
+                    bid_amount: bid,
+                    expected_version: currentVersion
+                })
+            }, { label: 'Bid' });
+            if (!data) return;
 
-                if (response.ok) {
-                    const result = await response.json();
-                    showMessage('Bid placed successfully!', 'success');
-                    currentVersion = result.new_version;
-                    // Blur the manual-bid box (if any) so the rail can rebuild post-commit.
-                    if (ae && ae.closest && ae.closest('.bidctl')) ae.blur();
-                    await refreshData();
-                    flashBid(ownerId);   // confirm the bid landed (no modal — speed)
-                } else {
-                    const error = await response.json();
-                    showMessage('Bid failed: ' + error.detail, 'error');
-                }
-            } catch (error) {
-                showMessage('Error placing bid: ' + error.message, 'error');
-            }
+            showMessage('Bid placed successfully!', 'success');
+            currentVersion = data.new_version;
+            // Blur the manual-bid box (if any) so the rail can rebuild post-commit.
+            if (ae && ae.closest && ae.closest('.bidctl')) ae.blur();
+            await refreshData();
+            flashBid(ownerId);   // confirm the bid landed (no modal — speed)
         }
 
         // ---------- Bid console: keyboard-driven live bidding ----------
@@ -806,64 +812,50 @@
         document.addEventListener('keydown', handleConsoleKey);
 
         async function completeDraft() {
+            // Pre-fetch for freshness so the version we send matches the data we read.
             try {
                 const draftState = await (await fetch('/api/v1/draft-state')).json();
                 if (!draftState.nominated) {
                     showMessage('No player nominated', 'error');
                     return;
                 }
-                // Sync module-level state with the fresh fetch so the version
-                // we send matches the data we read (prevents spurious 409s).
                 currentVersion = draftState.version;
                 currentDraftState = draftState;
-
-                const response = await fetch('/api/v1/draft', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        owner_id: draftState.nominated.current_bidder_id,
-                        player_id: draftState.nominated.player_id,
-                        final_price: draftState.nominated.current_bid,
-                        expected_version: draftState.version
-                    })
-                });
-                
-                if (response.ok) {
-                    const result = await response.json();
-                    showMessage('Player drafted successfully!', 'success');
-                    currentVersion = result.new_version;
-                    await refreshData();
-                } else {
-                    const error = await response.json();
-                    showMessage('Draft failed: ' + error.detail, 'error');
-                }
             } catch (error) {
-                showMessage('Error completing draft: ' + error.message, 'error');
+                showMessage('Error fetching draft state: ' + error.message, 'error');
+                return;
             }
+
+            const data = await apiCall('/api/v1/draft', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    owner_id: currentDraftState.nominated.current_bidder_id,
+                    player_id: currentDraftState.nominated.player_id,
+                    final_price: currentDraftState.nominated.current_bid,
+                    expected_version: currentVersion
+                })
+            }, { label: 'Draft' });
+            if (!data) return;
+
+            showMessage('Player drafted successfully!', 'success');
+            currentVersion = data.new_version;
+            await refreshData();
         }
 
         async function cancelNomination() {
-            try {
-                const response = await fetch('/api/v1/nominate', {
-                    method: 'DELETE',
-                    headers: { 
-                        'Content-Type': 'application/json',
-                        'If-Match': `"${currentVersion}"`
-                    }
-                });
-                
-                if (response.ok) {
-                    const result = await response.json();
-                    showMessage('Nomination cancelled', 'success');
-                    currentVersion = result.new_version;
-                    await refreshData();
-                } else {
-                    const error = await response.json();
-                    showMessage('Cancel failed: ' + error.detail, 'error');
+            const data = await apiCall('/api/v1/nominate', {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'If-Match': `"${currentVersion}"`
                 }
-            } catch (error) {
-                showMessage('Error cancelling nomination: ' + error.message, 'error');
-            }
+            }, { label: 'Cancel nomination' });
+            if (!data) return;
+
+            showMessage('Nomination cancelled', 'success');
+            currentVersion = data.new_version;
+            await refreshData();
         }
 
         function setTickerSpeed(s) {
@@ -898,14 +890,15 @@
         })();
 
         async function doReset() {
-            try {
-                const resp = await fetch('/api/v1/reset', {
-                    method: 'POST', headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ force: true })
-                });
-                if (resp.ok) { showMessage('Draft reset', 'success'); closeDrawer(); await refreshData(); }
-                else { const e = await resp.json(); showMessage('Reset failed: ' + e.detail, 'error'); }
-            } catch (err) { showMessage('Error resetting: ' + err.message, 'error'); }
+            const data = await apiCall('/api/v1/reset', {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ force: true })
+            }, { label: 'Reset' });
+            if (!data) return;
+
+            showMessage('Draft reset', 'success');
+            closeDrawer();
+            await refreshData();
         }
 
         function showMessage(text, type) {
@@ -962,38 +955,33 @@
             if (ok) showMessage('All done teams cleared', 'success');
         }
         async function patchTeamDone(ownerId, value) {
-            try {
-                const resp = await fetch(`/api/v1/teams/${ownerId}`, {
-                    method: 'PATCH',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ manually_done: value, expected_version: currentVersion })
-                });
-                if (resp.ok) {
-                    const r = await resp.json();
-                    currentVersion = r.new_version;
-                    if (value) showMessage('Team marked done', 'success');
-                    await refreshData();
-                    return true;
-                } else {
-                    const e = await resp.json();
-                    showMessage('Update failed: ' + e.detail, 'error');
-                    return false;
-                }
-            } catch (err) { showMessage('Error: ' + err.message, 'error'); return false; }
+            const data = await apiCall(`/api/v1/teams/${ownerId}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ manually_done: value, expected_version: currentVersion })
+            }, { label: 'Team update' });
+            if (!data) return false;
+
+            currentVersion = data.new_version;
+            if (value) showMessage('Team marked done', 'success');
+            await refreshData();
+            return true;
         }
 
         async function removeDraftedPlayer() {
             const sel = document.getElementById('remove-select');
             const pickId = parseInt(sel.value);
             if (!pickId) { showMessage('Please select a player to remove', 'error'); return; }
-            try {
-                const resp = await fetch(`/api/v1/draft/${pickId}`, {
-                    method: 'DELETE',
-                    headers: { 'Content-Type': 'application/json', 'If-Match': `"${currentVersion}"` }
-                });
-                if (resp.ok) { const r = await resp.json(); currentVersion = r.new_version; showMessage('Player removed', 'success'); await refreshData(); }
-                else { const e = await resp.json(); showMessage('Remove failed: ' + e.detail, 'error'); }
-            } catch (err) { showMessage('Error removing: ' + err.message, 'error'); }
+
+            const data = await apiCall(`/api/v1/draft/${pickId}`, {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json', 'If-Match': `"${currentVersion}"` }
+            }, { label: 'Remove player' });
+            if (!data) return;
+
+            currentVersion = data.new_version;
+            showMessage('Player removed', 'success');
+            await refreshData();
         }
 
         // Atomic pick transfer via single server-side endpoint.
@@ -1005,14 +993,16 @@
             if (!pickId || !targetOwnerId) { showMessage('Select a player and a target team', 'error'); return; }
             const price = parseInt(opt.dataset.price);
             if (isNaN(price)) { showMessage('Unable to parse pick price — aborting transfer', 'error'); return; }
-            try {
-                const resp = await fetch('/api/v1/admin/transfer', {
-                    method: 'POST', headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ pick_id: pickId, to_owner_id: targetOwnerId, expected_version: currentVersion })
-                });
-                if (resp.ok) { currentVersion = (await resp.json()).new_version; showMessage('Player transferred', 'success'); await refreshData(); }
-                else { const e = await resp.json(); showMessage('Transfer failed: ' + e.detail, 'error'); }
-            } catch (err) { showMessage('Error transferring: ' + err.message, 'error'); }
+
+            const data = await apiCall('/api/v1/admin/transfer', {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ pick_id: pickId, to_owner_id: targetOwnerId, expected_version: currentVersion })
+            }, { label: 'Transfer' });
+            if (!data) return;
+
+            currentVersion = data.new_version;
+            showMessage('Player transferred', 'success');
+            await refreshData();
         }
 
         // Admin draft functionality
@@ -1135,54 +1125,32 @@
                 return;
             }
             
-            try {
-                const response = await fetch('/api/v1/admin/draft', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({
-                        owner_id: ownerId,
-                        player_id: adminSelectedPlayerId,
-                        price: price,
-                        expected_version: currentVersion
-                    })
-                });
-                
-                if (response.ok) {
-                    const data = await response.json();
-                    currentVersion = data.new_version;
-                    
-                    // Save player name for success message before clearing
-                    const draftedPlayerName = adminSelectedPlayerName;
-                    
-                    // Clear the form
-                    document.getElementById('admin-player-search').value = '';
-                    document.getElementById('admin-owner-select').value = '';
-                    document.getElementById('admin-price-input').value = '';
-                    adminSelectedPlayerId = null;
-                    adminSelectedPlayerName = null;
-                    
-                    showMessage(`Successfully drafted ${draftedPlayerName} for $${price}`, 'success');
-                    
-                    // Refresh data - this updates all UI components
-                    console.log('Admin draft successful, refreshing data...');
-                    await refreshData();
-                    console.log('Data refresh complete');
-                } else {
-                    const errorData = await response.json();
-                    if (response.status === 409) {
-                        // Version mismatch, refresh and retry
-                        await refreshData();
-                        showMessage('Draft state changed, please try again', 'error');
-                    } else {
-                        showMessage(`Failed to draft player: ${errorData.detail}`, 'error');
-                    }
-                }
-            } catch (error) {
-                console.error('Error drafting player:', error);
-                showMessage('Failed to draft player', 'error');
-            }
+            const data = await apiCall('/api/v1/admin/draft', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    owner_id: ownerId,
+                    player_id: adminSelectedPlayerId,
+                    price: price,
+                    expected_version: currentVersion
+                })
+            }, { label: 'Admin draft' });
+            if (!data) return;
+
+            currentVersion = data.new_version;
+
+            // Save player name for success message before clearing
+            const draftedPlayerName = adminSelectedPlayerName;
+
+            // Clear the form
+            document.getElementById('admin-player-search').value = '';
+            document.getElementById('admin-owner-select').value = '';
+            document.getElementById('admin-price-input').value = '';
+            adminSelectedPlayerId = null;
+            adminSelectedPlayerName = null;
+
+            showMessage(`Successfully drafted ${draftedPlayerName} for $${price}`, 'success');
+            await refreshData();
         }
 
         // FOUT guard: reveal once webfonts are ready (--hu/cqw layout depends on metrics).

--- a/static/js/draft-shared.js
+++ b/static/js/draft-shared.js
@@ -87,7 +87,10 @@ function teamColor(teamAbbr) {
 }
 
 /* ── ESPN player headshot ─────────────────────────────────────────────────
-   D/ST has no headshot; callers substitute the team logo. */
+   D/ST has no headshot; callers substitute the team logo.
+   IMPORTANT: playerId must be an ESPN player ID — players.json IDs are ESPN
+   IDs by convention. If the data is ever sourced from a non-ESPN provider,
+   these URLs will 404. See DESIGN.md "Data Models > Player" for details. */
 function headshotUrl(playerId) {
     return `https://a.espncdn.com/combiner/i?img=/i/headshots/nfl/players/full/${playerId}.png&w=350&h=254`;
 }

--- a/static/js/team-viewer.js
+++ b/static/js/team-viewer.js
@@ -50,9 +50,10 @@
         function median(a){ const s=[...a].sort((x,y)=>x-y), m=s.length>>1; return s.length? (s.length%2? s[m] : (s[m-1]+s[m])/2) : 0; }
         function ab2(n){ return (n||'').slice(0,2).toUpperCase(); }
         // D/ST headshot falls back to the team logo (no player headshot for defenses).
+        // ESPN CDN images: hide on error so a CDN hiccup doesn't litter broken-image icons.
         const shotImg = (p, cls) => p.pos === 'D/ST'
-            ? `<img class="${cls} logo" src="${getTeamLogoUrl(p.nfl)}" alt="">`
-            : `<img class="${cls}" src="${headshotUrl(p.id)}" alt="">`;
+            ? `<img class="${cls} logo" src="${getTeamLogoUrl(p.nfl)}" alt="" onerror="this.style.display='none'">`
+            : `<img class="${cls}" src="${headshotUrl(p.id)}" alt="" onerror="this.style.display='none'">`;
         function defenseBye(teamAbbr){
             for (const id in playerStats){ const s = playerStats[id]; if (s && s.team === teamAbbr && s.bye_week) return s.bye_week; }
             return null;
@@ -215,7 +216,7 @@
             if (t) {
                 const url = new URL(window.location);
                 url.searchParams.set('team_id', t.owner_id);
-                window.history.pushState({}, '', url);
+                window.history.replaceState({}, '', url);
             }
             renderChips();
             renderTeamsView();
@@ -456,7 +457,7 @@
                 const byeChip = p.bye ? `<span class="pc-bye tnum">BYE ${p.bye}</span>` : '';
                 html += `<div class="pcard" style="--pc:${POSCOLOR[p.pos]};--tmc:${teamColor(p.nfl)}" data-idx="${idx}" onmouseenter="showTip(event,${idx})" onmousemove="moveTip(event)" onmouseleave="hideTip()">
       <div class="pc-photo">
-        <img class="pc-wm" src="${getTeamLogoUrl(p.nfl)}" alt="">
+        <img class="pc-wm" src="${getTeamLogoUrl(p.nfl)}" alt="" onerror="this.style.display='none'">
         ${shotImg(p, 'pc-shot')}
         <span class="pc-pos ${LIGHTPOS[p.pos] ? 'light' : ''}">${p.pos}</span>
         <div class="pc-corner"><span class="pc-price tnum">$${p.price}</span>${byeChip}</div>
@@ -659,6 +660,8 @@
                     <span class="ld-price tnum ${pcls}">$${r.price}</span></div>`;
             }).join('');
         }
+        // Production score -- intentionally distinct from booth's production_score
+        // (src/booth/slice.py) and ledger price tiers (valueTier below).
         function prodScore(p) {
             const st = playerStats[p.id]; if (!st) return -1;
             const n = v => num(v) || 0;
@@ -793,6 +796,8 @@
             else if (pos === 'K') { if (st.kicking) r.push(['FG Made', st.kicking.fgm, STATMAX.FG], ['FG%', st.kicking.fg_pct, 100], ['Long', st.kicking.long, 70], ['XP', st.kicking.xpm, STATMAX.XP], ['Points', st.kicking.points, STATMAX.PTS]); }
             return r;
         }
+        // Price tiers -- intentionally distinct from booth's production_score
+        // (src/booth/slice.py) and the viewer's prodScore above.
         // Plain-language read on a price vs the position's going rate. Uses the median
         // ratio (not spread): auction prices decay toward the $1 floor late, which wrecks
         // std-dev. $1 picks are treated as a neutral "minimum bid", never "below market".

--- a/static/js/team-viewer.js
+++ b/static/js/team-viewer.js
@@ -189,9 +189,9 @@
               :i===nextIdx?'<span class="chip-badge next">Next</span>'
               :done?'<span class="chip-badge done">✓ Full</span>':'';
             const cls=`chip ${i===selected?'active':''} ${i===clockIdx?'is-clock':''}`;
-            return `<div class="${cls}" style="--tc:${t.color}" onclick="selectTeam(${i})" title="View ${esc(t.team)}">
+            return `<button type="button" class="${cls}" style="--tc:${t.color}" onclick="selectTeam(${i})" title="View ${esc(t.team)}">
               <div class="ct">${esc(t.team)}</div>
-              <div class="chip-foot"><span class="co">${esc(t.owner)}</span>${badge}</div></div>`;
+              <div class="chip-foot"><span class="co">${esc(t.owner)}</span>${badge}</div></button>`;
           }).join('');
         }
         function renderClockNote(){
@@ -438,7 +438,11 @@
         const SKILL = { QB: 1, RB: 1, WR: 1, TE: 1 };   // positions where a shared bye actually hurts
         function setRosterMode(m) {
             rosterMode = m;
-            document.querySelectorAll('#rmode button').forEach(b => b.classList.toggle('active', b.id === 'rm-' + m));
+            document.querySelectorAll('#rmode button').forEach(b => {
+                const on = b.id === 'rm-' + m;
+                b.classList.toggle('active', on);
+                b.setAttribute('aria-pressed', String(on));
+            });
             renderRoster();
         }
         function renderRoster() {
@@ -622,8 +626,11 @@
         }
         const arrow = dir => dir > 0 ? ' <i class="ar">▲</i>' : ' <i class="ar">▼</i>';
         function thCells(elId, cols, activeKey, dir, setter) {
-            document.getElementById(elId).innerHTML = cols.map(c =>
-                `<span class="th ${c.cls || ''} ${activeKey === c.k ? 'active' : ''}" onclick="${setter}('${c.k}')">${c.lbl}${activeKey === c.k ? arrow(dir) : ''}</span>`).join('');
+            document.getElementById(elId).innerHTML = cols.map(c => {
+                const isActive = activeKey === c.k;
+                const ariaSort = isActive ? ` aria-sort="${dir > 0 ? 'ascending' : 'descending'}"` : '';
+                return `<span class="th ${c.cls || ''} ${isActive ? 'active' : ''}" role="button" tabindex="0"${ariaSort} onclick="${setter}('${c.k}')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();${setter}('${c.k}')}">${c.lbl}${isActive ? arrow(dir) : ''}</span>`;
+            }).join('');
         }
         function setLedgerSort(k) {
             if (ledgerSort === k) ledgerDir *= -1;
@@ -697,8 +704,8 @@
             const counts = {}; AVAILABLE.forEach(p => counts[p.pos] = (counts[p.pos] || 0) + 1);
             const order = RADAR_ORDER.filter(pos => counts[pos]);
             document.getElementById('availCount').textContent = `${AVAILABLE.length} left`;
-            const chips = [`<button class="af-chip ${availPos === 'ALL' ? 'active' : ''}" onclick="setAvailPos('ALL')">All <i>${AVAILABLE.length}</i></button>`]
-                .concat(order.map(pos => `<button class="af-chip ${availPos === pos ? 'active' : ''}" style="--pc:${POSCOLOR[pos]}" onclick="setAvailPos('${pos}')">${pos} <i>${counts[pos]}</i></button>`));
+            const chips = [`<button class="af-chip ${availPos === 'ALL' ? 'active' : ''}" aria-pressed="${availPos === 'ALL'}" onclick="setAvailPos('ALL')">All <i>${AVAILABLE.length}</i></button>`]
+                .concat(order.map(pos => `<button class="af-chip ${availPos === pos ? 'active' : ''}" aria-pressed="${availPos === pos}" style="--pc:${POSCOLOR[pos]}" onclick="setAvailPos('${pos}')">${pos} <i>${counts[pos]}</i></button>`));
             document.getElementById('availFilter').innerHTML = chips.join('');
             thCells('avHead', [{ k: 'pos', lbl: 'Pos', cls: 'ct' }, { k: 'name', lbl: 'Player' }, { k: 'team', lbl: 'Tm' }, { k: 'bye', lbl: 'Bye', cls: 'rt' }, { k: 'prod', lbl: STATS_YR, cls: 'rt' }], availSort, availDir, 'setAvailSort');
             const list = AVAILABLE.filter(p => availPos === 'ALL' || p.pos === availPos).sort(availCmp);
@@ -972,7 +979,11 @@
         }
         function setMatrixMode(m) {
             matrixMode = m;
-            document.querySelectorAll('#mxmode button').forEach(b => b.classList.toggle('active', b.id === 'mx-' + m));
+            document.querySelectorAll('#mxmode button').forEach(b => {
+                const on = b.id === 'mx-' + m;
+                b.classList.toggle('active', on);
+                b.setAttribute('aria-pressed', String(on));
+            });
             renderMatrix();
         }
         // Per-team aggregate by position: how many filled, and how many dollars spent.

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet">
+    <!-- Bump ?v= on link/script tags below when editing the referenced CSS/JS files -->
     <link rel="stylesheet" href="/static/css/draft-set-admin.css?v=10">
   </head>
   <body>

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -45,7 +45,10 @@
           <div class="rp-head">
             <div class="rp-title cond">Roster</div>
             <div class="rmode" id="rmode">
-              <button id="rm-cards" class="active" aria-pressed="true" onclick="setRosterMode('cards')">Cards</button>
+              <button id="rm-cards"
+                      class="active"
+                      aria-pressed="true"
+                      onclick="setRosterMode('cards')">Cards</button>
               <button id="rm-bye" aria-pressed="false" onclick="setRosterMode('bye')">Bye Weeks</button>
               <button id="rm-list" aria-pressed="false" onclick="setRosterMode('list')">List</button>
             </div>
@@ -171,8 +174,13 @@
               <h3>Roster Matrix</h3>
               <div class="ch-right">
                 <div class="rmode mxmode" id="mxmode">
-                  <button id="mx-count" class="active" aria-pressed="true" onclick="setMatrixMode('count')">#</button>
-                  <button id="mx-dollars" aria-pressed="false" onclick="setMatrixMode('dollars')">$</button>
+                  <button id="mx-count"
+                          class="active"
+                          aria-pressed="true"
+                          onclick="setMatrixMode('count')">#</button>
+                  <button id="mx-dollars"
+                          aria-pressed="false"
+                          onclick="setMatrixMode('dollars')">$</button>
                 </div>
                 <span class="card-note" id="matrixNote">filled vs max · gaps glow</span>
               </div>

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -44,9 +44,9 @@
           <div class="rp-head">
             <div class="rp-title cond">Roster</div>
             <div class="rmode" id="rmode">
-              <button id="rm-cards" class="active" onclick="setRosterMode('cards')">Cards</button>
-              <button id="rm-bye" onclick="setRosterMode('bye')">Bye Weeks</button>
-              <button id="rm-list" onclick="setRosterMode('list')">List</button>
+              <button id="rm-cards" class="active" aria-pressed="true" onclick="setRosterMode('cards')">Cards</button>
+              <button id="rm-bye" aria-pressed="false" onclick="setRosterMode('bye')">Bye Weeks</button>
+              <button id="rm-list" aria-pressed="false" onclick="setRosterMode('list')">List</button>
             </div>
           </div>
           <div class="roster-scroll">
@@ -170,8 +170,8 @@
               <h3>Roster Matrix</h3>
               <div class="ch-right">
                 <div class="rmode mxmode" id="mxmode">
-                  <button id="mx-count" class="active" onclick="setMatrixMode('count')">#</button>
-                  <button id="mx-dollars" onclick="setMatrixMode('dollars')">$</button>
+                  <button id="mx-count" class="active" aria-pressed="true" onclick="setMatrixMode('count')">#</button>
+                  <button id="mx-dollars" aria-pressed="false" onclick="setMatrixMode('dollars')">$</button>
                 </div>
                 <span class="card-note" id="matrixNote">filled vs max · gaps glow</span>
               </div>

--- a/templates/team_viewer.html
+++ b/templates/team_viewer.html
@@ -12,6 +12,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Saira+Condensed:wght@500;600;700;800;900&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet">
+    <!-- Bump ?v= on link/script tags below when editing the referenced CSS/JS files -->
     <link rel="stylesheet" href="/static/css/draft-set-viewer.css?v=4">
   </head>
   <body>


### PR DESCRIPTION
## Summary

Phase 4 (final) of the frontend review remediation (`FRONTEND_REVIEW.md`). Two parallel workstreams:

### R4 — Keyboard/ARIA accessibility (viewer)
- **Team chips**: Converted from `<div>` to `<button>` — natively keyboard-focusable and activatable
- **Sortable table headers**: Added `role="button"`, `tabindex="0"`, Enter/Space keydown handler, and `aria-sort` on the active column
- **Roster-mode toggles** (Cards/Bye/List): Added `aria-pressed` tracking
- **Matrix-mode toggles** (#/$): Added `aria-pressed` tracking
- **Available-player filter chips**: Added `aria-pressed` for active filter
- **Focus styles**: `:focus-visible` with `var(--electric)` outline for all interactive elements

### R5 — Smaller batchable items
- **R5a**: Viewer back button — changed `pushState` to `replaceState` so back leaves the page instead of stepping through team selections
- **R5b**: ESPN-id data contract — documented at `headshotUrl()` and in `DESIGN.md` that player IDs must be ESPN player IDs
- **R5c**: Image fallbacks — added `onerror` hide to viewer headshots and watermarks (CDN hiccup no longer litters broken-image icons)
- **R5d**: 409 handling consistency — extracted `apiCall()` helper in admin JS; all 9 mutating endpoints now auto-refresh on 409 with "state changed — please retry" toast (-19 lines net)
- **R5e**: Production-score cross-references — comments at all 3 formula locations noting they're intentionally distinct
- **R5f**: Cache-busting reminder — HTML comments near CSS/JS link tags

## Test plan

- [ ] 353 tests pass (`python -m pytest tests/ -x -q`)
- [ ] `djlint templates/` — 0 errors
- [ ] `ruff check src/ tests/` clean
- [ ] `node --check` passes on all 3 JS files
- [ ] Manual: Tab through viewer — chips and sort headers focusable, Enter/Space activates, visible focus ring
- [ ] Manual: `aria-pressed` toggles on roster/matrix mode buttons
- [ ] Manual: Press browser back on viewer — leaves page (doesn't step through teams)
- [ ] Manual: Trigger any 409 on admin — state auto-refreshes with retry toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)